### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/BlobCache.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/BlobCache.java
@@ -123,6 +123,11 @@ public class BlobCache implements Closeable {
     private byte[] mBlobHeader = new byte[BLOB_HEADER_SIZE];
     private Adler32 mAdler32 = new Adler32();
 
+    private int mSlotOffset;
+    private int mFileOffset;
+
+    private LookupRequest mLookupRequest = new LookupRequest();
+
     // Creates the cache. Three files will be created:
     // path + ".idx", path + ".0", and path + ".1"
     // The ".0" file and the ".1" file each stores data for a region. Each of
@@ -407,7 +412,6 @@ public class BlobCache implements Closeable {
 
     // This method is for one-off lookup. For repeated lookup, use the version
     // accepting LookupRequest to avoid repeated memory allocation.
-    private LookupRequest mLookupRequest = new LookupRequest();
     public byte[] lookup(long key) throws IOException {
         mLookupRequest.key = key;
         mLookupRequest.buffer = null;
@@ -531,8 +535,6 @@ public class BlobCache implements Closeable {
     // insertion.
     // If the lookup is successful, the file offset is also saved in
     // mFileOffset.
-    private int mSlotOffset;
-    private int mFileOffset;
     private boolean lookupInternal(long key, int hashStart) {
         int slot = (int) (key % mMaxEntries);
         if (slot < 0) slot += mMaxEntries;

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/DraftCache.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/DraftCache.java
@@ -35,6 +35,12 @@ package com.moez.QKSMS.common.google;
 public class DraftCache {
     private static final String TAG = "Mms/draft";
 
+    static final String[] DRAFT_PROJECTION = new String[] {
+        Conversations.THREAD_ID           // 0
+    };
+
+    static final int COLUMN_DRAFT_THREAD_ID = 0;
+
     private static DraftCache sInstance;
 
     private final Context mContext;
@@ -60,12 +66,6 @@ public class DraftCache {
         mContext = context;
         refresh();
     }
-
-    static final String[] DRAFT_PROJECTION = new String[] {
-            Conversations.THREAD_ID           // 0
-    };
-
-    static final int COLUMN_DRAFT_THREAD_ID = 0;
 
     /** To be called whenever the draft state might have changed.
      *  Dispatches work to a thread and returns immediately.

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/SimpleCache.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/SimpleCache.java
@@ -29,6 +29,8 @@ import java.util.LinkedHashMap;
  * from Peter Balwin and books app.
  */
 public class SimpleCache<K, V> {
+    private final SoftReferenceMap mSoftReferences;
+    private final HardReferenceMap mHardReferences;
 
     /**
      * A simple LRU cache to prevent the number of {@link java.util.Map.Entry} instances
@@ -66,13 +68,6 @@ public class SimpleCache<K, V> {
         }
     }
 
-    private static <V> V unwrap(SoftReference<V> ref) {
-        return ref != null ? ref.get() : null;
-    }
-
-    private final SoftReferenceMap mSoftReferences;
-    private final HardReferenceMap mHardReferences;
-
     /**
      * Constructor.
      *
@@ -93,6 +88,10 @@ public class SimpleCache<K, V> {
             mSoftReferences = new SoftReferenceMap(initialCapacity, maxCapacity, loadFactor);
             mHardReferences = null;
         }
+    }
+
+    private static <V> V unwrap(SoftReference<V> ref) {
+        return ref != null ? ref.get() : null;
     }
 
     /**

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/UriImage.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/UriImage.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class UriImage {
+    private static final int NUMBER_OF_RESIZE_ATTEMPTS = 4;
     private static final String TAG = "Mms/image";
     private static final boolean DEBUG = false;
     private static final boolean LOCAL_LOGV = false;
@@ -258,8 +259,6 @@ public class UriImage {
 
         return part;
     }
-
-    private static final int NUMBER_OF_RESIZE_ATTEMPTS = 4;
 
     /**
      * Resize and recompress the image such that it fits the given limits. The resulting byte


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava