### PR TITLE
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order

### DIFF
--- a/QKSMS/src/main/java/android/net/DhcpInfoInternal.java
+++ b/QKSMS/src/main/java/android/net/DhcpInfoInternal.java
@@ -33,9 +33,9 @@ import java.util.Collections;
  * @hide
  */
 public class DhcpInfoInternal {
-    private final static String TAG = "DhcpInfoInternal";
+    private static final String TAG = "DhcpInfoInternal";
 
-    private final static boolean LOCAL_LOGV = false;
+    private static final boolean LOCAL_LOGV = false;
     public String ipAddress;
     public int prefixLength;
 

--- a/QKSMS/src/main/java/android/net/IConnectivityManager.java
+++ b/QKSMS/src/main/java/android/net/IConnectivityManager.java
@@ -15,7 +15,7 @@ public interface IConnectivityManager extends android.os.IInterface {
     /**
      * Local-side IPC implementation stub class.
      */
-    public static abstract class Stub extends android.os.Binder implements android.net.IConnectivityManager {
+    public abstract static class Stub extends android.os.Binder implements android.net.IConnectivityManager {
         private static final String DESCRIPTOR = "android.net.IConnectivityManager";
 
         /**

--- a/QKSMS/src/main/java/android/net/INetworkPolicyListener.java
+++ b/QKSMS/src/main/java/android/net/INetworkPolicyListener.java
@@ -11,7 +11,7 @@ public interface INetworkPolicyListener extends android.os.IInterface {
     /**
      * Local-side IPC implementation stub class.
      */
-    public static abstract class Stub extends android.os.Binder implements android.net.INetworkPolicyListener {
+    public abstract static class Stub extends android.os.Binder implements android.net.INetworkPolicyListener {
         private static final String DESCRIPTOR = "android.net.INetworkPolicyListener";
 
         /**

--- a/QKSMS/src/main/java/android/net/INetworkPolicyManager.java
+++ b/QKSMS/src/main/java/android/net/INetworkPolicyManager.java
@@ -13,7 +13,7 @@ public interface INetworkPolicyManager extends android.os.IInterface {
     /**
      * Local-side IPC implementation stub class.
      */
-    public static abstract class Stub extends android.os.Binder implements android.net.INetworkPolicyManager {
+    public abstract static class Stub extends android.os.Binder implements android.net.INetworkPolicyManager {
         private static final String DESCRIPTOR = "android.net.INetworkPolicyManager";
 
         /**

--- a/QKSMS/src/main/java/android/net/LinkCapabilities.java
+++ b/QKSMS/src/main/java/android/net/LinkCapabilities.java
@@ -65,28 +65,28 @@ public class LinkCapabilities implements Parcelable {
          *
          * @see ConnectivityManager
          */
-        public final static int RO_NETWORK_TYPE = 1;
+        public static final int RO_NETWORK_TYPE = 1;
 
         /**
          * Desired minimum forward link (download) bandwidth for the
          * in kilobits per second (kbps). Values should be strings such
          * "50", "100", "1500", etc.
          */
-        public final static int RW_DESIRED_FWD_BW = 2;
+        public static final int RW_DESIRED_FWD_BW = 2;
 
         /**
          * Required minimum forward link (download) bandwidth, in
          * per second (kbps), below which the socket cannot function.
          * Values should be strings such as "50", "100", "1500", etc.
          */
-        public final static int RW_REQUIRED_FWD_BW = 3;
+        public static final int RW_REQUIRED_FWD_BW = 3;
 
         /**
          * Available forward link (download) bandwidth for the socket.
          * This value is in kilobits per second (kbps).
          * Values will be strings such as "50", "100", "1500", etc.
          */
-        public final static int RO_AVAILABLE_FWD_BW = 4;
+        public static final int RO_AVAILABLE_FWD_BW = 4;
 
         /**
          * Desired minimum reverse link (upload) bandwidth for the socket
@@ -95,7 +95,7 @@ public class LinkCapabilities implements Parcelable {
          * <p/>
          * This key is set via the needs map.
          */
-        public final static int RW_DESIRED_REV_BW = 5;
+        public static final int RW_DESIRED_REV_BW = 5;
 
         /**
          * Required minimum reverse link (upload) bandwidth, in kilobits
@@ -103,21 +103,21 @@ public class LinkCapabilities implements Parcelable {
          * If a rate is not specified, the default rate of kbps will be
          * Values should be strings such as "50", "100", "1500", etc.
          */
-        public final static int RW_REQUIRED_REV_BW = 6;
+        public static final int RW_REQUIRED_REV_BW = 6;
 
         /**
          * Available reverse link (upload) bandwidth for the socket.
          * This value is in kilobits per second (kbps).
          * Values will be strings such as "50", "100", "1500", etc.
          */
-        public final static int RO_AVAILABLE_REV_BW = 7;
+        public static final int RO_AVAILABLE_REV_BW = 7;
 
         /**
          * Maximum latency for the socket, in milliseconds, above which
          * socket cannot function.
          * Values should be strings such as "50", "300", "500", etc.
          */
-        public final static int RW_MAX_ALLOWED_LATENCY = 8;
+        public static final int RW_MAX_ALLOWED_LATENCY = 8;
 
         /**
          * Interface that the socket is bound to. This can be a virtual
@@ -125,7 +125,7 @@ public class LinkCapabilities implements Parcelable {
          * (e.g. wlan0 or rmnet0).
          * Values will be strings such as "wlan0", "rmnet0"
          */
-        public final static int RO_BOUND_INTERFACE = 9;
+        public static final int RO_BOUND_INTERFACE = 9;
 
         /**
          * Physical interface that the socket is routed on.
@@ -134,7 +134,7 @@ public class LinkCapabilities implements Parcelable {
          * if seamless mobility is supported.
          * Values will be strings such as "wlan0", "rmnet0"
          */
-        public final static int RO_PHYSICAL_INTERFACE = 10;
+        public static final int RO_PHYSICAL_INTERFACE = 10;
     }
 
     /**

--- a/QKSMS/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
+++ b/QKSMS/src/main/java/com/google/android/mms/pdu_alt/PduComposer.java
@@ -34,11 +34,11 @@ public class PduComposer {
     /**
      * Address type.
      */
-    static private final int PDU_PHONE_NUMBER_ADDRESS_TYPE = 1;
-    static private final int PDU_EMAIL_ADDRESS_TYPE = 2;
-    static private final int PDU_IPV4_ADDRESS_TYPE = 3;
-    static private final int PDU_IPV6_ADDRESS_TYPE = 4;
-    static private final int PDU_UNKNOWN_ADDRESS_TYPE = 5;
+    private static final int PDU_PHONE_NUMBER_ADDRESS_TYPE = 1;
+    private static final int PDU_EMAIL_ADDRESS_TYPE = 2;
+    private static final int PDU_IPV4_ADDRESS_TYPE = 3;
+    private static final int PDU_IPV6_ADDRESS_TYPE = 4;
+    private static final int PDU_UNKNOWN_ADDRESS_TYPE = 5;
 
     /**
      * Address regular expression string.
@@ -63,25 +63,25 @@ public class PduComposer {
     /**
      * Error values.
      */
-    static private final int PDU_COMPOSE_SUCCESS = 0;
-    static private final int PDU_COMPOSE_CONTENT_ERROR = 1;
-    static private final int PDU_COMPOSE_FIELD_NOT_SET = 2;
-    static private final int PDU_COMPOSE_FIELD_NOT_SUPPORTED = 3;
+    private static final int PDU_COMPOSE_SUCCESS = 0;
+    private static final int PDU_COMPOSE_CONTENT_ERROR = 1;
+    private static final int PDU_COMPOSE_FIELD_NOT_SET = 2;
+    private static final int PDU_COMPOSE_FIELD_NOT_SUPPORTED = 3;
 
     /**
      * WAP values defined in WSP spec.
      */
-    static private final int QUOTED_STRING_FLAG = 34;
-    static private final int END_STRING_FLAG = 0;
-    static private final int LENGTH_QUOTE = 31;
-    static private final int TEXT_MAX = 127;
-    static private final int SHORT_INTEGER_MAX = 127;
-    static private final int LONG_INTEGER_LENGTH_MAX = 8;
+    private static final int QUOTED_STRING_FLAG = 34;
+    private static final int END_STRING_FLAG = 0;
+    private static final int LENGTH_QUOTE = 31;
+    private static final int TEXT_MAX = 127;
+    private static final int SHORT_INTEGER_MAX = 127;
+    private static final int LONG_INTEGER_LENGTH_MAX = 8;
 
     /**
      * Block size when read data from InputStream.
      */
-    static private final int PDU_COMPOSER_BLOCK_SIZE = 1024;
+    private static final int PDU_COMPOSER_BLOCK_SIZE = 1024;
     private static final String TAG = "PduComposer";
 
     /**
@@ -1029,7 +1029,7 @@ public class PduComposer {
     /**
      *  Record current message informations.
      */
-    static private class LengthRecordNode {
+    private static class LengthRecordNode {
         ByteArrayOutputStream currentMessage = null;
         public int currentPosition = 0;
 

--- a/QKSMS/src/main/java/com/google/android/mms/pdu_alt/PduPersister.java
+++ b/QKSMS/src/main/java/com/google/android/mms/pdu_alt/PduPersister.java
@@ -903,7 +903,7 @@ public class PduPersister {
      * Here <table_name> shall be "video" or "audio" or "images"
      * <row_index> the index of the content in given table
      */
-    static public String convertUriToPath(Context context, Uri uri) {
+    public static String convertUriToPath(Context context, Uri uri) {
         String path = null;
         if (null != uri) {
             String scheme = uri.getScheme();

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/google/Recycler.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/google/Recycler.java
@@ -104,9 +104,9 @@ public abstract class Recycler {
         return /*prefs.getBoolean(MessagingPreferenceActivity.AUTO_DELETE, DEFAULT_AUTO_DELETE)*/ false;
     }
 
-    abstract public int getMessageLimit(Context context);
+    public abstract int getMessageLimit(Context context);
 
-    abstract public void setMessageLimit(Context context, int limit);
+    public abstract void setMessageLimit(Context context, int limit);
 
     public int getMessageMinLimit() {
         return MmsConfig.getMinMessageCountPerThread();
@@ -116,15 +116,15 @@ public abstract class Recycler {
         return MmsConfig.getMaxMessageCountPerThread();
     }
 
-    abstract protected long getThreadId(Cursor cursor);
+    protected abstract long getThreadId(Cursor cursor);
 
-    abstract protected Cursor getAllThreads(Context context);
+    protected abstract Cursor getAllThreads(Context context);
 
-    abstract protected void deleteMessagesForThread(Context context, long threadId, int keep);
+    protected abstract void deleteMessagesForThread(Context context, long threadId, int keep);
 
-    abstract protected void dumpMessage(Cursor cursor, Context context);
+    protected abstract void dumpMessage(Cursor cursor, Context context);
 
-    abstract protected boolean anyThreadOverLimit(Context context);
+    protected abstract boolean anyThreadOverLimit(Context context);
 
     public static class SmsRecycler extends Recycler {
         private static final String[] ALL_SMS_THREADS_PROJECTION = {
@@ -135,7 +135,7 @@ public abstract class Recycler {
         private static final int ID             = 0;
         private static final int MESSAGE_COUNT  = 1;
 
-        static private final String[] SMS_MESSAGE_PROJECTION = new String[] {
+        private static final String[] SMS_MESSAGE_PROJECTION = new String[] {
             BaseColumns._ID,
             Conversations.THREAD_ID,
             Sms.ADDRESS,
@@ -148,14 +148,14 @@ public abstract class Recycler {
 
         // The indexes of the default columns which must be consistent
         // with above PROJECTION.
-        static private final int COLUMN_ID                  = 0;
-        static private final int COLUMN_THREAD_ID           = 1;
-        static private final int COLUMN_SMS_ADDRESS         = 2;
-        static private final int COLUMN_SMS_BODY            = 3;
-        static private final int COLUMN_SMS_DATE            = 4;
-        static private final int COLUMN_SMS_READ            = 5;
-        static private final int COLUMN_SMS_TYPE            = 6;
-        static private final int COLUMN_SMS_STATUS          = 7;
+        private static final int COLUMN_ID                  = 0;
+        private static final int COLUMN_THREAD_ID           = 1;
+        private static final int COLUMN_SMS_ADDRESS         = 2;
+        private static final int COLUMN_SMS_BODY            = 3;
+        private static final int COLUMN_SMS_DATE            = 4;
+        private static final int COLUMN_SMS_READ            = 5;
+        private static final int COLUMN_SMS_TYPE            = 6;
+        private static final int COLUMN_SMS_STATUS          = 7;
 
         private final String MAX_SMS_MESSAGES_PER_THREAD = "MaxSmsMessagesPerThread";
 
@@ -283,7 +283,7 @@ public abstract class Recycler {
         private static final int ID             = 0;
         private static final int MESSAGE_COUNT  = 1;
 
-        static private final String[] MMS_MESSAGE_PROJECTION = new String[] {
+        private static final String[] MMS_MESSAGE_PROJECTION = new String[] {
             BaseColumns._ID,
             Conversations.THREAD_ID,
             Mms.DATE,
@@ -291,10 +291,10 @@ public abstract class Recycler {
 
         // The indexes of the default columns which must be consistent
         // with above PROJECTION.
-        static private final int COLUMN_ID                  = 0;
-        static private final int COLUMN_THREAD_ID           = 1;
-        static private final int COLUMN_MMS_DATE            = 2;
-        static private final int COLUMN_MMS_READ            = 3;
+        private static final int COLUMN_ID                  = 0;
+        private static final int COLUMN_THREAD_ID           = 1;
+        private static final int COLUMN_MMS_DATE            = 2;
+        private static final int COLUMN_MMS_READ            = 3;
 
         private final String MAX_MMS_MESSAGES_PER_THREAD = "MaxMmsMessagesPerThread";
 

--- a/QKSMS/src/main/java/com/moez/QKSMS/external/iab/Base64.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/external/iab/Base64.java
@@ -40,21 +40,21 @@ package com.moez.QKSMS.external.iab;
  */
 public class Base64 {
     /** Specify encoding (value is {@code true}). */
-    public final static boolean ENCODE = true;
+    public  static final boolean ENCODE = true;
 
     /** Specify decoding (value is {@code false}). */
-    public final static boolean DECODE = false;
+    public static final boolean DECODE = false;
 
     /** The equals sign (=) as a byte. */
-    private final static byte EQUALS_SIGN = (byte) '=';
+    private static final byte EQUALS_SIGN = (byte) '=';
 
     /** The new line character (\n) as a byte. */
-    private final static byte NEW_LINE = (byte) '\n';
+    private static final byte NEW_LINE = (byte) '\n';
 
     /**
      * The 64 valid Base64 values.
      */
-    private final static byte[] ALPHABET =
+    private static final byte[] ALPHABET =
         {(byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F',
         (byte) 'G', (byte) 'H', (byte) 'I', (byte) 'J', (byte) 'K',
         (byte) 'L', (byte) 'M', (byte) 'N', (byte) 'O', (byte) 'P',
@@ -72,7 +72,7 @@ public class Base64 {
     /**
      * The 64 valid web safe Base64 values.
      */
-    private final static byte[] WEBSAFE_ALPHABET =
+    private static final byte[] WEBSAFE_ALPHABET =
         {(byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F',
         (byte) 'G', (byte) 'H', (byte) 'I', (byte) 'J', (byte) 'K',
         (byte) 'L', (byte) 'M', (byte) 'N', (byte) 'O', (byte) 'P',
@@ -91,7 +91,7 @@ public class Base64 {
      * Translates a Base64 value to either its 6-bit reconstruction value
      * or a negative number indicating some other meaning.
      **/
-    private final static byte[] DECODABET = {-9, -9, -9, -9, -9, -9, -9, -9, -9, // Decimal  0 -  8
+    private static final byte[] DECODABET = {-9, -9, -9, -9, -9, -9, -9, -9, -9, // Decimal  0 -  8
         -5, -5, // Whitespace: Tab and Linefeed
         -9, -9, // Decimal 11 - 12
         -5, // Whitespace: Carriage Return
@@ -125,7 +125,7 @@ public class Base64 {
     };
 
     /** The web safe decodabet */
-    private final static byte[] WEBSAFE_DECODABET =
+    private static final byte[] WEBSAFE_DECODABET =
         {-9, -9, -9, -9, -9, -9, -9, -9, -9, // Decimal  0 -  8
         -5, -5, // Whitespace: Tab and Linefeed
         -9, -9, // Decimal 11 - 12
@@ -161,9 +161,9 @@ public class Base64 {
         };
 
     // Indicates white space in encoding
-    private final static byte WHITE_SPACE_ENC = -5;
+    private static final byte WHITE_SPACE_ENC = -5;
     // Indicates equals sign in encoding
-    private final static byte EQUALS_SIGN_ENC = -1;
+    private static final byte EQUALS_SIGN_ENC = -1;
 
     /** Defeats instantiation. */
     private Base64() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
Please let me know if you have any questions.
George Kankava