### PR TITLE
squid:S1161 - '@Override' annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/model/SlideModel.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/model/SlideModel.java
@@ -279,16 +279,19 @@ public class SlideModel extends Model implements List<MediaModel>, EventListener
      * @throws ContentRestrictionException when can not add this object.
      *
      */
+    @Override
     public boolean add(MediaModel object) {
         internalAdd(object);
         notifyModelChanged(true);
         return true;
     }
 
+    @Override
     public boolean addAll(Collection<? extends MediaModel> collection) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public void clear() {
         if (mMedia.size() > 0) {
             for (MediaModel media : mMedia) {
@@ -312,22 +315,27 @@ public class SlideModel extends Model implements List<MediaModel>, EventListener
         }
     }
 
+    @Override
     public boolean contains(Object object) {
         return mMedia.contains(object);
     }
 
+    @Override
     public boolean containsAll(Collection<?> collection) {
         return mMedia.containsAll(collection);
     }
 
+    @Override
     public boolean isEmpty() {
         return mMedia.isEmpty();
     }
 
+    @Override
     public Iterator<MediaModel> iterator() {
         return mMedia.iterator();
     }
 
+    @Override
     public boolean remove(Object object) {
         if ((object != null) && (object instanceof MediaModel)
                 && internalRemove(object)) {
@@ -337,35 +345,43 @@ public class SlideModel extends Model implements List<MediaModel>, EventListener
         return false;
     }
 
+    @Override
     public boolean removeAll(Collection<?> collection) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public boolean retainAll(Collection<?> collection) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public int size() {
         return mMedia.size();
     }
 
+    @Override
     public Object[] toArray() {
         return mMedia.toArray();
     }
 
+    @Override
     public <T> T[] toArray(T[] array) {
         return mMedia.toArray(array);
     }
 
+    @Override
     public void add(int location, MediaModel object) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public boolean addAll(int location,
             Collection<? extends MediaModel> collection) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public MediaModel get(int location) {
         if (mMedia.size() == 0) {
             return null;
@@ -374,22 +390,27 @@ public class SlideModel extends Model implements List<MediaModel>, EventListener
         return mMedia.get(location);
     }
 
+    @Override
     public int indexOf(Object object) {
         return mMedia.indexOf(object);
     }
 
+    @Override
     public int lastIndexOf(Object object) {
         return mMedia.lastIndexOf(object);
     }
 
+    @Override
     public ListIterator<MediaModel> listIterator() {
         return mMedia.listIterator();
     }
 
+    @Override
     public ListIterator<MediaModel> listIterator(int location) {
         return mMedia.listIterator(location);
     }
 
+    @Override
     public MediaModel remove(int location) {
         MediaModel media = mMedia.get(location);
         if ((media != null) && internalRemove(media)) {
@@ -398,10 +419,12 @@ public class SlideModel extends Model implements List<MediaModel>, EventListener
         return media;
     }
 
+    @Override
     public MediaModel set(int location, MediaModel object) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public List<MediaModel> subList(int start, int end) {
         return mMedia.subList(start, end);
     }

--- a/QKSMS/src/main/java/com/moez/QKSMS/model/SlideshowModel.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/model/SlideshowModel.java
@@ -406,6 +406,7 @@ public class SlideshowModel extends Model
     //
     // Implement List<E> interface.
     //
+    @Override
     public boolean add(SlideModel object) {
         int increaseSize = object.getSlideSize();
         checkMessageSize(increaseSize);
@@ -422,10 +423,12 @@ public class SlideshowModel extends Model
         return false;
     }
 
+    @Override
     public boolean addAll(Collection<? extends SlideModel> collection) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public void clear() {
         if (mSlides.size() > 0) {
             for (SlideModel slide : mSlides) {
@@ -440,22 +443,27 @@ public class SlideshowModel extends Model
         }
     }
 
+    @Override
     public boolean contains(Object object) {
         return mSlides.contains(object);
     }
 
+    @Override
     public boolean containsAll(Collection<?> collection) {
         return mSlides.containsAll(collection);
     }
 
+    @Override
     public boolean isEmpty() {
         return mSlides.isEmpty();
     }
 
+    @Override
     public Iterator<SlideModel> iterator() {
         return mSlides.iterator();
     }
 
+    @Override
     public boolean remove(Object object) {
         if ((object != null) && mSlides.remove(object)) {
             SlideModel slide = (SlideModel) object;
@@ -467,26 +475,32 @@ public class SlideshowModel extends Model
         return false;
     }
 
+    @Override
     public boolean removeAll(Collection<?> collection) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public boolean retainAll(Collection<?> collection) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public int size() {
         return mSlides.size();
     }
 
+    @Override
     public Object[] toArray() {
         return mSlides.toArray();
     }
 
+    @Override
     public <T> T[] toArray(T[] array) {
         return mSlides.toArray(array);
     }
 
+    @Override
     public void add(int location, SlideModel object) {
         if (object != null) {
             int increaseSize = object.getSlideSize();
@@ -502,31 +516,38 @@ public class SlideshowModel extends Model
         }
     }
 
+    @Override
     public boolean addAll(int location,
             Collection<? extends SlideModel> collection) {
         throw new UnsupportedOperationException("Operation not supported.");
     }
 
+    @Override
     public SlideModel get(int location) {
         return (location >= 0 && location < mSlides.size()) ? mSlides.get(location) : null;
     }
 
+    @Override
     public int indexOf(Object object) {
         return mSlides.indexOf(object);
     }
 
+    @Override
     public int lastIndexOf(Object object) {
         return mSlides.lastIndexOf(object);
     }
 
+    @Override
     public ListIterator<SlideModel> listIterator() {
         return mSlides.listIterator();
     }
 
+    @Override
     public ListIterator<SlideModel> listIterator(int location) {
         return mSlides.listIterator(location);
     }
 
+    @Override
     public SlideModel remove(int location) {
         SlideModel slide = mSlides.remove(location);
         if (slide != null) {
@@ -537,6 +558,7 @@ public class SlideshowModel extends Model
         return slide;
     }
 
+    @Override
     public SlideModel set(int location, SlideModel object) {
         SlideModel slide = mSlides.get(location);
         if (null != object) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1161 - '@Override' annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1161
Please let me know if you have any questions.
George Kankava