### PR TITLE
[fix #569] Cleaning: remove compileOptions.encoding

### DIFF
--- a/QKSMS/build.gradle
+++ b/QKSMS/build.gradle
@@ -52,8 +52,6 @@ android {
     }
 
     compileOptions {
-        compileOptions.encoding = "UTF-8"
-
         // Use Java 1.7, requires minSdk 8
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
This line has no effect because:
- UTF-8 is the default encoding charset
- Type: compileOptions is specified two times instead of one