### PR TITLE
Fix crash when backPress from SettingsActivity after Orientation changed

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsActivity.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsActivity.java
@@ -17,11 +17,14 @@ public class SettingsActivity extends QKSwipeBackActivity {
         mSettingsFragment = (SettingsFragment) fm.findFragmentByTag(SettingsFragment.TAG);
         if (mSettingsFragment == null) {
             mSettingsFragment = SettingsFragment.newInstance(R.xml.settings_main);
+            fm.beginTransaction()
+                    .replace(R.id.content_frame, mSettingsFragment, SettingsFragment.TAG)
+                    .commit();
+        } else {
+            fm.beginTransaction()
+                    .show(mSettingsFragment)
+                    .commit();
         }
-
-        fm.beginTransaction()
-                .replace(R.id.content_frame, mSettingsFragment, SettingsFragment.TAG)
-                .commit();
     }
 
     @Override


### PR DESCRIPTION
### Corrects also the bad behavior : After screen rotation, it will return to main Settings screen automatically

### DESCRIPTION
QKSMS crashes when pressing Back button from Settings Activity after Orientation change.
This bug happens both in version on Google Play and built from Github.
It only happens when rotating screen in Category (Appearance, General, Notifications, MMS, QK Reply, etc. ) of Settings.

### STEPS
1. Start QKSMS
2. Go to Settings by clicking on the OptionMenu -> Settings
3. Click on one Category in the list
4. When you are in the Category (for example, **General**), rotate the screen
5. After screen rotation, it will return to main Settings screen automatically (which is also not good)
6. Click on Back button

### EXPECTED
Return to the Conversations Activity which contains the conversation list.

### OBSERVATIONS
Crashes.

### Logcat from Android Studio

    FATAL EXCEPTION: main
    Process: com.moez.QKSMS, PID: 22003
    java.lang.IllegalStateException: Fragment already added: SettingsFragment{1d41d5f0 #0 id=0x7f0e0085 SettingsFragment}
    at android.app.FragmentManagerImpl.addFragment(FragmentManager.java:1153)
    at android.app.BackStackRecord.popFromBackStack(BackStackRecord.java:1547)

### Please try it and decide what to do about this issue. Maybe you can come out with a better solution.

Thank you very much. I love QKSMS. It is great!