### PR TITLE
Protect broadcast receivers from spoofing

### DIFF
--- a/QKSMS/src/main/AndroidManifest.xml
+++ b/QKSMS/src/main/AndroidManifest.xml
@@ -415,7 +415,8 @@
         <!-- Legacy broadcast receiver for SMS -->
         <receiver
             android:name=".receiver.SmsReceiverLegacy"
-            android:enabled="@bool/preKitKat">
+            android:enabled="@bool/preKitKat"
+            android:permission="android.permission.BROADCAST_SMS">
             <intent-filter android:priority="2147483647">
                 <action android:name="android.provider.Telephony.SMS_RECEIVED" />
             </intent-filter>

--- a/QKSMS/src/main/AndroidManifest.xml
+++ b/QKSMS/src/main/AndroidManifest.xml
@@ -438,27 +438,37 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
-        <receiver android:name=".mmssms.SentReceiver">
+        <receiver
+            android:name=".mmssms.SentReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.moez.QKSMS.SMS_SENT" />
             </intent-filter>
         </receiver>
-        <receiver android:name=".receiver.DeliveredReceiver">
+        <receiver
+            android:name=".receiver.DeliveredReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.moez.QKSMS.SMS_DELIVERED" />
             </intent-filter>
         </receiver>
-        <receiver android:name=".receiver.MessageFailedReceiver">
+        <receiver
+            android:name=".receiver.MessageFailedReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.moez.QKSMS.NOTIFY_SMS_FAILURE" />
             </intent-filter>
         </receiver>
-        <receiver android:name=".receiver.MarkReadReceiver">
+        <receiver
+            android:name=".receiver.MarkReadReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.moez.QKSMS.MARK_READ" />
             </intent-filter>
         </receiver>
-        <receiver android:name=".receiver.MarkSeenReceiver">
+        <receiver
+            android:name=".receiver.MarkSeenReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.moez.QKSMS.MARK_SEEN" />
             </intent-filter>


### PR DESCRIPTION
- BroadcastReceiver for internal usage are not exported. This ensure that another applications cannot spoof QKSMS.
Note: pending intent can be used without an exported BroadcastReceiver (see https://developer.android.com/reference/android/app/PendingIntent.html).
- BroadcastReceiver for SMS_RECEIVED intent is protected with permission BROADCAST_SMS. Because this permission is a system permission, only system can send to QKSMS a SMS_RECEIVED intent.