### PR TITLE
Remove FLASHLIGHT and CAMERA permissions which are not necessary

### DIFF
--- a/QKSMS/src/main/AndroidManifest.xml
+++ b/QKSMS/src/main/AndroidManifest.xml
@@ -7,11 +7,9 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CALL_PHONE" />
-    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-    <uses-permission android:name="android.permission.FLASHLIGHT" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />


### PR DESCRIPTION
### DESCRIPTION
The Intent **MediaStore.ACTION_IMAGE_CAPTURE** (android.media.action.IMAGE_CAPTURE) already does taking-photo when user wants to send a photo MMS. Permissions android.permission.CAMERA and android.permission.FLASHLIGHT seem not necessary.

To be removed perhaps.

Issue https://github.com/moezbhatti/qksms/issues/593