### PR TITLE
Fix Draft SMS is not saved in some context

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/enums/QKPreference.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/enums/QKPreference.java
@@ -99,7 +99,6 @@ public enum QKPreference {
     CONVERSATION_THEME("conversation_theme"),
 
     // Storage
-    COMPOSE_DRAFT("compose_draft", ""),
     LAST_AUTO_DELETE_CHECK("last_auto_delete_check", 0);
 
     private String mKey;

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/compose/ComposeActivity.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/compose/ComposeActivity.java
@@ -4,8 +4,13 @@ import android.app.FragmentManager;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
+import android.view.ViewGroup;
+
 import com.moez.QKSMS.R;
+import com.moez.QKSMS.mmssms.Utils;
 import com.moez.QKSMS.ui.base.QKSwipeBackActivity;
+import com.moez.QKSMS.ui.dialog.DefaultSmsHelper;
+import com.moez.QKSMS.ui.dialog.QKDialog;
 
 public class ComposeActivity extends QKSwipeBackActivity {
 
@@ -31,5 +36,28 @@ public class ComposeActivity extends QKSwipeBackActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         new MenuInflater(this).inflate(R.menu.compose, menu);
         return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public void onBackPressed() {
+        // Check if we're not the default SMS app
+        if (!Utils.isDefaultSmsApp(this)) {
+            // Ask to become the default SMS app
+            new DefaultSmsHelper(this, R.string.not_default_send)
+                    .showIfNotDefault((ViewGroup)getWindow().getDecorView().getRootView());
+        } else if (mComposeFragment != null && !mComposeFragment.isReplyTextEmpty()
+                && mComposeFragment.getRecipientAddresses().length == 0) {
+            // If there is Draft message and no recipients are set
+            new QKDialog()
+                    .setContext(this)
+                    .setMessage(R.string.discard_message_reason)
+                    .setPositiveButton(R.string.yes, v -> {
+                        super.onBackPressed();
+                    })
+                    .setNegativeButton(R.string.cancel, null)
+                    .show();
+        } else {
+            super.onBackPressed();
+        }
     }
 }

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/compose/ComposeFragment.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/compose/ComposeFragment.java
@@ -105,4 +105,11 @@ public class ComposeFragment extends QKFragment implements ActivityLauncher, Rec
         mStarredContactsView.collapse();
         mComposeView.requestReplyTextFocus();
     }
+
+    public boolean isReplyTextEmpty() {
+        if (mComposeView != null) {
+            return mComposeView.isReplyTextEmpty();
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
For Issue https://github.com/moezbhatti/qksms/issues/609

With this patch, draft is well saved when user presses Back button.  

**Except when no recipient is set.**

> Please decide what to do for the case when no recipient is set and user presses Back button. 
The behavior of standard SMS App on Android Mobile  is showing a Dialog with Title "Discard message"; Message "No recipients have been selected. This message will be discarded." ; PositiveButton is "Discard", which discards the Draft and returns to Message List Activity ; NegativeButton is "Cancel", which does nothing and dismisses the Dialog.

Thanks a lot!