### PR TITLE
Update build.gradle to 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }


### PR DESCRIPTION
The release notes are here: https://developer.android.com/studio/releases/gradle-plugin.html

Some of the more interesting updates:

- Security fix
- Auto-download SDK deps when building from command line
- **Experimental gradle cachine feature, should speed up builds!**
    - "A new experimental caching feature lets Gradle speed up build times by pre-dexing, storing, and reusing the pre-dexed versions of your libraries."
    - Read about how to run it [here](http://tools.android.com/tech-docs/build-cache)
- New packaging pipeline. They say you can revert back to the old versions, but I don't know why you would want to do that...
- New signing scheme so if someone changes the QKSMS APK binary (like change a URL string to their servers or something) the Android platform won't even install it
- **Specify which classes go in the main DEX file**. This will speed up the startup of the app since it runs the main DEX file first and the others after.
- Some performance improvement for native libs apps. I'm not sure if QKSMS uses native libs?