### PR TITLE
Create lint file, fixes moezbhatti/qksms#658

### DIFF
--- a/QKSMS/lint.xml
+++ b/QKSMS/lint.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+      <!-- Disable the annoying "InnerClasses attribute for an anonymous inner class"
+           warning. -->
+       <ignore regexp="warning: Ignoring InnerClasses attribute for an anonymous inner class" />
+       <ignore regexp="(freemarker\..*) that doesn't come with an" />
+       <ignore regexp="associated EnclosingMethod attribute. This class was probably produced by a" />
+       <ignore regexp="compiler that did not target the modern \.class file format\. The recommended" />
+       <ignore regexp="solution is to recompile the class from source, using an up-to-date compiler" />
+       <ignore regexp="and without specifying any &quot;-target&quot; type options\. The consequence of ignoring" />
+       <ignore regexp="this warning is that reflective operations on this class will incorrectly" />
+       <ignore regexp="indicate that it is *not* an inner class\." />
+</lint>


### PR DESCRIPTION
There is some ProGuard issue with inner classes in one of the libraries
that we're using in QKSMS. One warning is written as 8 errors in the
linter, and there's like 98 warnings (one for each class), so we get
700+ errors. The only consequence of ignoring the warning is this:

```
The consequence of ignoring this warning is that reflective
operations on this class will incorrectly indicate that it is *not*
an inner class. [From the warning message itself.]
```

It doesn't seem likely that QKSMS is going to break because the classes
in a library are being reported as not an inner class during reflection.
So I've disabled the printing of the errors with a lint.xml file.

You can read more about disabling error messages here:
http://tools.android.com/tips/lint/suppressing-lint-warnings
