### PR TITLE
Fix bug with empty avatars and app crashes

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/ConversationSettingsDialog.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/ConversationSettingsDialog.java
@@ -7,8 +7,10 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.Preference;
+import android.text.TextUtils;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+
 import com.moez.QKSMS.R;
 import com.moez.QKSMS.common.ConversationPrefsHelper;
 import com.moez.QKSMS.common.utils.Units;
@@ -117,8 +119,7 @@ public class ConversationSettingsDialog extends QKDialog implements Preference.O
 
             case SettingsFragment.NOTIFICATION_TONE:
                 Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
-                Uri uri = Uri.parse(mConversationPrefs.getString(SettingsFragment.NOTIFICATION_TONE, "content://settings/system/notification_sound"));
-                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, uri);
+                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, getRingtoneUri());
                 intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true);
                 intent.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI, RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION));
                 intent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, true);
@@ -131,6 +132,11 @@ public class ConversationSettingsDialog extends QKDialog implements Preference.O
         }
 
         return true;
+    }
+
+    private Uri getRingtoneUri() {
+        final String uriString = mConversationPrefs.getString(SettingsFragment.NOTIFICATION_TONE, "content://settings/system/notification_sound");
+        return !TextUtils.isEmpty(uriString) ? Uri.parse(uriString) : null;
     }
 
 }

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/messagelist/MessageListActivity.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/messagelist/MessageListActivity.java
@@ -10,6 +10,7 @@ import android.text.Html;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
+
 import com.moez.QKSMS.R;
 import com.moez.QKSMS.common.AnalyticsManager;
 import com.moez.QKSMS.common.ConversationPrefsHelper;
@@ -146,7 +147,8 @@ public class MessageListActivity extends QKSwipeBackActivity {
                 if (mWaitingForThreadId > 0) {
                     ConversationPrefsHelper conversationPrefs = new ConversationPrefsHelper(this, mWaitingForThreadId);
                     Uri uri = data.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
-                    conversationPrefs.putString(SettingsFragment.NOTIFICATION_TONE, uri.toString());
+                    conversationPrefs.putString(SettingsFragment.NOTIFICATION_TONE, (uri == null) ? "" : uri.toString());
+
                     mWaitingForThreadId = -1;
                 }
             }

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/view/AvatarView.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/view/AvatarView.java
@@ -189,10 +189,9 @@ public class AvatarView extends ImageView implements View.OnClickListener {
     }
 
     private boolean isPhoneNumberFormat(String name) {
-//        We already checked it in first "if" condition in "setContactName"
-//        if (TextUtils.isEmpty(name)) {
-//            return false;
-//        }
+        if (TextUtils.isEmpty(name)) {
+            return false;
+        }
 
         char c = name.charAt(0);
         return !name.contains("@") && (c == '+' || c == '(' || Character.isDigit(c));

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/view/AvatarView.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/view/AvatarView.java
@@ -22,6 +22,7 @@ import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.ImageView;
+
 import com.moez.QKSMS.R;
 import com.moez.QKSMS.common.LiveViewManager;
 import com.moez.QKSMS.common.TypefaceManager;
@@ -53,6 +54,7 @@ public class AvatarView extends ImageView implements View.OnClickListener {
     private String mInitial = "#";
     private Paint mPaint;
     private Drawable mDefaultDrawable;
+    private int mYOffset;
 
     /**
      * When setImageDrawable is called with a drawable, we circle crop to size of this view and use
@@ -88,6 +90,8 @@ public class AvatarView extends ImageView implements View.OnClickListener {
                 }
             }
             a.recycle();
+
+            mYOffset = (int) ((mPaint.descent() + mPaint.ascent()) / 2);
 
             setOnClickListener(this);
 
@@ -175,7 +179,7 @@ public class AvatarView extends ImageView implements View.OnClickListener {
             if (mOriginalDrawable == null) super.setImageDrawable(null);
         } else if (isPhoneNumberFormat(name)) {
             mInitial = "";
-            super.setImageDrawable(mDefaultDrawable);
+            if (mOriginalDrawable == null) super.setImageDrawable(mDefaultDrawable);
         } else {
             mInitial = "" + name.toUpperCase().charAt(0);
             if (mOriginalDrawable == null) super.setImageDrawable(null);
@@ -185,9 +189,10 @@ public class AvatarView extends ImageView implements View.OnClickListener {
     }
 
     private boolean isPhoneNumberFormat(String name) {
-        if (TextUtils.isEmpty(name)) {
-            return false;
-        }
+//        We already checked it in first "if" condition in "setContactName"
+//        if (TextUtils.isEmpty(name)) {
+//            return false;
+//        }
 
         char c = name.charAt(0);
         return !name.contains("@") && (c == '+' || c == '(' || Character.isDigit(c));
@@ -276,7 +281,7 @@ public class AvatarView extends ImageView implements View.OnClickListener {
 
         if (getDrawable() == null && !isInEditMode()) {
             int xPos = (getWidth() / 2);
-            int yPos = (int) ((getHeight() / 2) - ((mPaint.descent() + mPaint.ascent()) / 2));
+            int yPos = (getHeight() / 2) - mYOffset;
             canvas.drawText("" + mInitial, xPos, yPos, mPaint);
         }
     }


### PR DESCRIPTION
- There were problem, that if you have several contacts, whose names starts with "+", their avatars not displayed in conversations list, or displays as white circles.
- Minor tweak for "onDraw" function
- App crashed when select "Silent" ringtone in conversation setting