### PR TITLE
Add text-via-MMS option

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/enums/QKPreference.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/enums/QKPreference.java
@@ -80,6 +80,7 @@ public enum QKPreference {
     // MMS
     GROUP_MESSAGING("pref_key_compose_group", true),
     AUTOMATIC_DATA("pref_key_auto_data", true),
+    TEXT_VIA_MMS("pref_key_texts_as_mms", false),
     LONG_AS_MMS("", true),
     LONG_AS_MMS_AFTER("", true),
     MAX_MMS_SIZE("", true),

--- a/QKSMS/src/main/java/com/moez/QKSMS/mmssms/Transaction.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/mmssms/Transaction.java
@@ -141,7 +141,7 @@ public class Transaction {
      */
     public void sendNewMessage(Message message, long threadId) {
         this.saveMessage = message.getSave();
-        boolean mmsShortCircuit = PreferenceManager.getDefaultSharedPreferences(context).getBoolean("pref_key_texts_as_mms", true);
+        boolean mmsShortCircuit = QKPreferences.getBoolean(QKPreference.TEXT_VIA_MMS);
         // if message:
         //      1) Has images attached
         // or

--- a/QKSMS/src/main/java/com/moez/QKSMS/mmssms/Transaction.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/mmssms/Transaction.java
@@ -38,6 +38,7 @@ import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
+import android.preference.PreferenceManager;
 
 import com.android.mms.dom.smil.parser.SmilXmlSerializer;
 import com.android.mms.transaction.HttpUtils;
@@ -140,7 +141,7 @@ public class Transaction {
      */
     public void sendNewMessage(Message message, long threadId) {
         this.saveMessage = message.getSave();
-
+        boolean mmsShortCircuit = PreferenceManager.getDefaultSharedPreferences(context).getBoolean("pref_key_texts_as_mms", true);
         // if message:
         //      1) Has images attached
         // or
@@ -152,7 +153,7 @@ public class Transaction {
         //      2) group messaging is enabled
         //
         // then, send as MMS, else send as Voice or SMS
-        if (checkMMS(message)) {
+        if (checkMMS(message) || mmsShortCircuit) {
             try { Looper.prepare(); } catch (Exception e) { }
             RateController.init(context);
             DownloadManager.init(context);

--- a/QKSMS/src/main/res/values/strings.xml
+++ b/QKSMS/src/main/res/values/strings.xml
@@ -196,6 +196,8 @@
     <string name="pref_auto_download_summary">Automatically download MMS messages when they become available</string>
     <string name="pref_auto_data">Automatic data</string>
     <string name="pref_auto_data_summary">Turn on data automatically when sending or receiving MMS</string>
+    <string name="pref_send_texts_as_mms">Send texts as MMS</string>
+    <string name="pref_send_texts_as_mms_summary">Send text messages via MMS instead of SMS</string>
     <string name="pref_split">Split SMS</string>
     <string name="pref_split_summary">Split long messages into separate messages</string>
     <string name="pref_split_counter">Split counter</string>

--- a/QKSMS/src/main/res/xml/settings_mms.xml
+++ b/QKSMS/src/main/res/xml/settings_mms.xml
@@ -26,6 +26,13 @@
         android:summary="@string/pref_auto_data_summary"
         android:title="@string/pref_auto_data"
         android:widgetLayout="@layout/view_switch" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="pref_key_texts_as_mms"
+        android:layout="@layout/list_item_preference"
+        android:summary="@string/pref_send_texts_as_mms_summary"
+        android:title="@string/pref_send_texts_as_mms"
+        android:widgetLayout="@layout/view_switch" />
     <PreferenceCategory
         android:layout="@layout/list_item_preference_category"
         android:title="@string/pref_category_sending_mms">


### PR DESCRIPTION
This adds an option under the MMS settings submenu that allows one to short-circuit the MMS check logic, thus sending all text messages via MMS rather than SMS. See #712 for reasoning.

Tested personally, it works. Not the way I would have don it if I were at home, but alas I am not.
fixes #712 