### PR TITLE
fixed issue#645

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/transaction/NotificationManager.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/transaction/NotificationManager.java
@@ -246,7 +246,7 @@ public class NotificationManager {
 
                 // If there are no messages, don't try to create a notification
                 // If this app is not default message app, don't try to create a notification either
-                if (conversations.size() == 0||!(new DefaultSmsHelper(context, 0).isDefault())) {
+                if (conversations.size() == 0 || !new DefaultSmsHelper(context, 0).isDefault()) {
                     return;
                 }
 

--- a/QKSMS/src/main/java/com/moez/QKSMS/transaction/NotificationManager.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/transaction/NotificationManager.java
@@ -36,6 +36,7 @@ import com.moez.QKSMS.model.SlideshowModel;
 import com.moez.QKSMS.receiver.RemoteMessagingReceiver;
 import com.moez.QKSMS.ui.MainActivity;
 import com.moez.QKSMS.ui.ThemeManager;
+import com.moez.QKSMS.ui.dialog.DefaultSmsHelper;
 import com.moez.QKSMS.ui.messagelist.MessageItem;
 import com.moez.QKSMS.ui.messagelist.MessageListActivity;
 import com.moez.QKSMS.ui.popup.QKComposeActivity;
@@ -244,7 +245,8 @@ public class NotificationManager {
                 dismissOld(context, conversations);
 
                 // If there are no messages, don't try to create a notification
-                if (conversations.size() == 0) {
+                // If this app is not default message app, don't try to create a notification either
+                if (conversations.size() == 0||!(new DefaultSmsHelper(context, 0).isDefault())) {
                     return;
                 }
 

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/DefaultSmsHelper.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/DefaultSmsHelper.java
@@ -84,4 +84,8 @@ public class DefaultSmsHelper implements ActionClickListener {
 
         return snackbarType;
     }
+
+    public boolean isDefault() {
+        return mIsDefault;
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }


### PR DESCRIPTION
Fixed issue#645 that notification will show again when dismissed if the app is not the default message app.
The bug is because when you dismissed the notifications, it called the update method in NotificationManager who dismissed the old notifications and make new notifications if there are still "unseen" notifications. Since the app is not the default sms app, it can't set the unseen messages seen before the "update" is called. So it will make notifications again and again.
I added a public isDefault() method in DefaultSmsHelper which simply returns the mIsDefault.
I then make the update return (and not make any new notifications) when it is not the default sms app. It is natural, since you don't want a not default sms app to show notifications about the sms.
Anyway, it fixed the bug.
