### PR TITLE
Patternblock

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/common/BlockedConversationHelper.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/BlockedConversationHelper.java
@@ -55,16 +55,18 @@ public class BlockedConversationHelper {
         return prefs.getStringSet(SettingsFragment.BLOCKED_SENDERS, new HashSet<String>());
     }
 
-    public static void blockFutureConversation(SharedPreferences prefs, String address) {
+    public static boolean blockFutureConversation(SharedPreferences prefs, String address) {
         Set<String> idStrings = prefs.getStringSet(SettingsFragment.BLOCKED_FUTURE, new HashSet<String>());
-        idStrings.add(address);
+        final boolean modified = idStrings.add(address);
         prefs.edit().putStringSet(SettingsFragment.BLOCKED_FUTURE, idStrings).apply();
+        return modified;
     }
 
-    public static void unblockFutureConversation(SharedPreferences prefs, String address) {
+    public static boolean unblockFutureConversation(SharedPreferences prefs, String address) {
         Set<String> idStrings2 = prefs.getStringSet(SettingsFragment.BLOCKED_FUTURE, new HashSet<String>());
-        idStrings2.remove(address);
+        final boolean modified = idStrings2.remove(address);
         prefs.edit().putStringSet(SettingsFragment.BLOCKED_FUTURE, idStrings2).apply();
+        return modified;
     }
 
     public static Set<String> getFutureBlockedConversations(SharedPreferences prefs) {

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/BlockedConversationHelper.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/BlockedConversationHelper.java
@@ -17,9 +17,11 @@ import com.moez.QKSMS.transaction.SmsHelper;
 import com.moez.QKSMS.ui.messagelist.MessageColumns;
 import com.moez.QKSMS.ui.settings.SettingsFragment;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Observable;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -239,7 +241,7 @@ public class BlockedConversationHelper {
         }
 
         if(body != null && !body.isEmpty()) {
-            body = preProcessForWordByWordCheck(body);
+            body = body.trim().toLowerCase();
 
             final String word = getBlockedWordOf(prefs, body);
             if(word != null) {
@@ -260,20 +262,6 @@ public class BlockedConversationHelper {
     // ------------------- BLOCK BY WORD BLACKLIST
 
     /**
-     * Whether if {@link String#trim()} should be called on every blacklisted word.
-     *
-     * See {@link #preProcessForWordByWordCheck(String)}
-     */
-    private static final boolean TRIM_WORD = false;
-
-    /**
-     * Whether if checking against blacklisted words is case-sensitive or not.
-     *
-     * See {@link #preProcessForWordByWordCheck(String)}
-     */
-    private static final boolean CASE_SENSITIVE_WORD = false;
-
-    /**
      * Add a word to spam list. If a message contains that word, it's *probably* spam.
      *
      * @param prefs app shared pref.
@@ -282,7 +270,11 @@ public class BlockedConversationHelper {
      */
     public static boolean blockWord(SharedPreferences prefs, String value) {
 
-        value = preProcessForWordByWordCheck(value);
+        String value1 = value;
+
+        value1 = value1.toLowerCase().trim();
+
+        value = value1;
 
         final String key = SettingsFragment.BLOCKED_WORD;
         final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
@@ -302,7 +294,11 @@ public class BlockedConversationHelper {
      */
     public static boolean unblockWord(SharedPreferences prefs, String value) {
 
-        value = preProcessForWordByWordCheck(value);
+        String value1 = value;
+
+        value1 = value1.toLowerCase().trim();
+
+        value = value1;
 
         final String key = SettingsFragment.BLOCKED_WORD;
         final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
@@ -333,28 +329,18 @@ public class BlockedConversationHelper {
      * @return the first seen spam word in text or null of none was found.
      * @see #getBlockedWords(SharedPreferences)
      */
-    private static String getBlockedWordOf(SharedPreferences prefs, final String value) {
+    private static String getBlockedWordOf(SharedPreferences prefs, String value) {
+
+        value = value.replaceAll("\\s", " ");
+        final List<String> split = Arrays.asList(value.split(" "));
+
+        // NO regex used, utf support for \w, \s, and \b character classes is very clunky.
 
         for (final String each : getBlockedWords(prefs))
-            if (value.contains(each))
+            if (split.contains(each))
                 return each;
 
         return null;
-    }
-
-    /**
-     * PreProcess body of a message (or a spam word, before adding it to list) before checking it
-     * for spam words.
-     */
-    private static String preProcessForWordByWordCheck(String value) {
-
-        if(TRIM_WORD)
-            value = value.trim();
-
-        if(!CASE_SENSITIVE_WORD)
-            value = value.toLowerCase();
-
-        return value;
     }
 
     // -------------------------- BLOCK BY PATTERN

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/BlockedConversationHelper.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/BlockedConversationHelper.java
@@ -10,15 +10,19 @@ import android.util.Log;
 import android.view.MenuItem;
 import com.moez.QKSMS.R;
 import com.moez.QKSMS.common.utils.PhoneNumberUtils;
+import com.moez.QKSMS.data.Contact;
 import com.moez.QKSMS.data.Conversation;
 import com.moez.QKSMS.data.Message;
 import com.moez.QKSMS.transaction.SmsHelper;
 import com.moez.QKSMS.ui.messagelist.MessageColumns;
 import com.moez.QKSMS.ui.settings.SettingsFragment;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Observable;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * A set of helper methods to group the logic related to blocked conversation
@@ -187,4 +191,318 @@ public class BlockedConversationHelper {
             }
         }
     }
+
+
+    /**
+     * Return true if a message from a sender should be blocked.
+     */
+    public static boolean isBlocked(final SharedPreferences prefs,
+                                    final Context context,
+                                    final Message message,
+                                    final String address,
+                                    String body,
+                                    final long date) {
+
+        if(!prefs.getBoolean(SettingsFragment.BLOCK_ENABLED, false))
+            return false;
+
+        if (prefs.getBoolean(SettingsFragment.BLOCK_SKIP_CONTACTS, true) &&
+                Contact.get(message.getAddress(), true).existsInDatabase()) {
+            Log.d("QKSMS::Blocker", "skipping spam check from contact: " + address);
+            return false;
+        }
+
+        if(address != null && !address.isEmpty()) {
+            if (isFutureBlocked(prefs, address)) {
+                Log.i("QKSMS::Blocker", "blocked from <" + address + "> because of address blacklist");
+                return true;
+            }
+
+            final String numberPrefix0 = getBlockedNumberPrefixOf(prefs, address);
+            if(numberPrefix0 != null) {
+                Log.i("QKSMS::Blocker", "blocked from <" + address + "> because of number prefix: " + numberPrefix0);
+                return true;
+            }
+
+            String rippedAddr = "";
+            for(int i = 0; i < address.length(); i++) {
+                final Character c = address.charAt(i);
+                if('0' <= c && c <= '9')
+                    rippedAddr += c;
+            }
+
+            final String numberPrefix1 = getBlockedNumberPrefixOf(prefs, rippedAddr);
+            if(numberPrefix1 != null) {
+                Log.i("QKSMS::Blocker", "blocked from <" + address + "> because of number prefix: " + numberPrefix1);
+                return true;
+            }
+        }
+
+        if(body != null && !body.isEmpty()) {
+            body = preProcessForWordByWordCheck(body);
+
+            final String word = getBlockedWordOf(prefs, body);
+            if(word != null) {
+                Log.i("QKSMS::Blocker", "blocked from <" + address + "> because of spam words: " + word);
+                return true;
+            }
+
+            final String pattern = getBlockedPatternOf(prefs, body);
+            if(pattern != null) {
+                Log.i("QKSMS::Blocker", "blocked from <" + address + "> because of spam pattern: " + pattern);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // ------------------- BLOCK BY WORD BLACKLIST
+
+    /**
+     * Whether if {@link String#trim()} should be called on every blacklisted word.
+     *
+     * See {@link #preProcessForWordByWordCheck(String)}
+     */
+    private static final boolean TRIM_WORD = false;
+
+    /**
+     * Whether if checking against blacklisted words is case-sensitive or not.
+     *
+     * See {@link #preProcessForWordByWordCheck(String)}
+     */
+    private static final boolean CASE_SENSITIVE_WORD = false;
+
+    /**
+     * Add a word to spam list. If a message contains that word, it's *probably* spam.
+     *
+     * @param prefs app shared pref.
+     * @return true if the value did not exist in the collection before, and hence the collection was modified.
+     * @see #getBlockedWords(SharedPreferences)
+     */
+    public static boolean blockWord(SharedPreferences prefs, String value) {
+
+        value = preProcessForWordByWordCheck(value);
+
+        final String key = SettingsFragment.BLOCKED_WORD;
+        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
+        final boolean modified = values.add(value);
+        prefs.edit().putStringSet(key, values).apply();
+
+        return modified;
+    }
+
+    /**
+     * Remove a word from spam list.
+     *
+     * @param prefs app shared pref.
+     * @param value the value to remove.
+     * @return true if the value actually existed in the collection, and hence the collection was modified.
+     * @see #getBlockedWords(SharedPreferences)
+     */
+    public static boolean unblockWord(SharedPreferences prefs, String value) {
+
+        value = preProcessForWordByWordCheck(value);
+
+        final String key = SettingsFragment.BLOCKED_WORD;
+        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
+        final boolean modified = values.remove(value);
+        prefs.edit().putStringSet(key, values).apply();
+
+        return modified;
+    }
+
+    /**
+     * List of all blacklisted words (spam words). If a message contains any of
+     * these words, it's probably spam and should be blocked.
+     *
+     * @param prefs app shared pref.
+     * @return collection of all the words considered to be spam if seen in a message.
+     */
+    public static Collection<String> getBlockedWords(SharedPreferences prefs) {
+
+        final String key = SettingsFragment.BLOCKED_WORD;
+        return prefs.getStringSet(key, Collections.emptySet());
+    }
+
+    /**
+     * Returns the first seen spam word in the {@code text}, null if none was found.
+     *
+     * @param prefs app shared pref.
+     * @param value body of the the message to check.
+     * @return the first seen spam word in text or null of none was found.
+     * @see #getBlockedWords(SharedPreferences)
+     */
+    private static String getBlockedWordOf(SharedPreferences prefs, final String value) {
+
+        for (final String each : getBlockedWords(prefs))
+            if (value.contains(each))
+                return each;
+
+        return null;
+    }
+
+    /**
+     * PreProcess body of a message (or a spam word, before adding it to list) before checking it
+     * for spam words.
+     */
+    private static String preProcessForWordByWordCheck(String value) {
+
+        if(TRIM_WORD)
+            value = value.trim();
+
+        if(!CASE_SENSITIVE_WORD)
+            value = value.toLowerCase();
+
+        return value;
+    }
+
+    // -------------------------- BLOCK BY PATTERN
+
+    /**
+     * Add a pattern to list of spam patterns.
+     *
+     * @param prefs app shared pref.
+     * @return true if the value did not exist in the collection before, and hence the collection was modified.
+     * @see #getBlockedPatterns(SharedPreferences)
+     */
+    public static boolean blockPattern(SharedPreferences prefs, final String value) {
+
+        if(compilePattern(value) == null)
+            return false;
+
+        final String key = SettingsFragment.BLOCKED_PATTERN;
+        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
+        final boolean modified = values.add(value);
+        prefs.edit().putStringSet(key, values).apply();
+
+        return modified;
+    }
+
+    /**
+     * Remove a value from the list of spam patterns.
+     *
+     * @param prefs app shared pref.
+     * @param value the value to remove.
+     * @return true if the value actually existed in the collection, and hence the collection was modified.
+     * @see #getBlockedPatterns(SharedPreferences)
+     */
+    public static boolean unblockPattern(SharedPreferences prefs, final String value) {
+
+        final String key = SettingsFragment.BLOCKED_PATTERN;
+        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
+        final boolean modified = values.remove(value);
+        prefs.edit().putStringSet(key, values).apply();
+
+        return modified;
+    }
+
+    /**
+     * Collection of all patterns considered to be spam. If a message matches
+     * against any of these patterns, then the message is spam and should be
+     * blocked.
+     *
+     * @param prefs app shared pref
+     * @return Collection of all patterns considered to be spam.
+     */
+    public static Collection<String> getBlockedPatterns(SharedPreferences prefs) {
+
+        final String key = SettingsFragment.BLOCKED_PATTERN;
+        return prefs.getStringSet(key, Collections.emptySet());
+    }
+
+    /**
+     * Returns the first spam pattern the {@code value} matches against, null if none
+     * was found.
+     *
+     * @param prefs app shared pref.
+     * @param value body of the the message to check.
+     * @see #getBlockedPatterns(SharedPreferences)
+     */
+    private static String getBlockedPatternOf(SharedPreferences prefs, final String value) {
+
+        Pattern regex;
+        for (final String each : getBlockedPatterns(prefs)) {
+            regex = compilePattern(each);
+            if (regex != null) {
+                if (regex.matcher(value).matches())
+                    return each;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Try to compile a regex pattern but do not raise any error for invalid patterns,
+     * return null instead.
+     */
+    public static Pattern compilePattern(final String pattern) {
+
+        if(pattern == null || pattern.isEmpty()) {
+            Log.e("QKSMS::Blocker", "empty pattern");
+            return null;
+        }
+
+        try {
+            return Pattern.compile(pattern.trim());
+        }
+        catch (final Exception e) {
+            Log.e("QKSMS::Blocker", "invalid pattern: " + pattern);
+            return null;
+        }
+    }
+
+    // -------------------- BLOCK BY NUMBER PREFIX
+
+    public static boolean blockNumberPrefix(SharedPreferences prefs, final String value) {
+
+        final String key = SettingsFragment.BLOCKED_NUMBER_PREFIX;
+        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
+        final boolean modified = values.add(value);
+        prefs.edit().putStringSet(key, values).apply();
+
+        return modified;
+    }
+
+    public static boolean unblockNumberPrefix(SharedPreferences prefs, final String value) {
+
+        final String key = SettingsFragment.BLOCKED_NUMBER_PREFIX;
+        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
+        final boolean modified = values.remove(value);
+        prefs.edit().putStringSet(key, values).apply();
+
+        return modified;
+    }
+
+    /**
+     * Returns collection of all the number prefixes considered to be spam. If a
+     * messages arrives from a number, and that numbers prefix is in this list,
+     * that message is considered to be spam and should be blocked.
+     *
+     * @param prefs app shared pref.
+     * @return collection of all the number prefixes considered to be spam.
+     */
+    public static Collection<String> getBlockedNumberPrefixes(SharedPreferences prefs) {
+
+        final String key = SettingsFragment.BLOCKED_NUMBER_PREFIX;
+        return prefs.getStringSet(key, Collections.emptySet());
+    }
+
+    /**
+     * Returns the first number prefix found, null if none was found.
+     *
+     * @param prefs app shared pref.
+     * @param value body of the the message to check.
+     * @see #getBlockedPatterns(SharedPreferences)
+     */
+    private static String getBlockedNumberPrefixOf(SharedPreferences prefs, final String value) {
+
+        for (final String each : getBlockedNumberPrefixes(prefs))
+            if (value.startsWith(each))
+                return each;
+
+        return null;
+    }
+
 }

--- a/QKSMS/src/main/java/com/moez/QKSMS/common/BlockedConversationHelper.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/common/BlockedConversationHelper.java
@@ -259,6 +259,21 @@ public class BlockedConversationHelper {
         return false;
     }
 
+    private static boolean modifyCollection(SharedPreferences prefs,
+                                            String value,
+                                            String key,
+                                            boolean isAdd) {
+
+        value = value.toLowerCase().trim();
+        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
+        final boolean modified = isAdd ? values.add(value) : values.remove(value);
+
+        if(modified)
+            prefs.edit().putStringSet(key, values).apply();
+
+        return modified;
+    }
+
     // ------------------- BLOCK BY WORD BLACKLIST
 
     /**
@@ -266,22 +281,10 @@ public class BlockedConversationHelper {
      *
      * @param prefs app shared pref.
      * @return true if the value did not exist in the collection before, and hence the collection was modified.
-     * @see #getBlockedWords(SharedPreferences)
      */
     public static boolean blockWord(SharedPreferences prefs, String value) {
 
-        String value1 = value;
-
-        value1 = value1.toLowerCase().trim();
-
-        value = value1;
-
-        final String key = SettingsFragment.BLOCKED_WORD;
-        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
-        final boolean modified = values.add(value);
-        prefs.edit().putStringSet(key, values).apply();
-
-        return modified;
+        return modifyCollection(prefs, value, SettingsFragment.BLOCKED_WORD, true);
     }
 
     /**
@@ -290,22 +293,10 @@ public class BlockedConversationHelper {
      * @param prefs app shared pref.
      * @param value the value to remove.
      * @return true if the value actually existed in the collection, and hence the collection was modified.
-     * @see #getBlockedWords(SharedPreferences)
      */
     public static boolean unblockWord(SharedPreferences prefs, String value) {
 
-        String value1 = value;
-
-        value1 = value1.toLowerCase().trim();
-
-        value = value1;
-
-        final String key = SettingsFragment.BLOCKED_WORD;
-        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
-        final boolean modified = values.remove(value);
-        prefs.edit().putStringSet(key, values).apply();
-
-        return modified;
+        return modifyCollection(prefs, value, SettingsFragment.BLOCKED_WORD, false);
     }
 
     /**
@@ -318,6 +309,7 @@ public class BlockedConversationHelper {
     public static Collection<String> getBlockedWords(SharedPreferences prefs) {
 
         final String key = SettingsFragment.BLOCKED_WORD;
+
         return prefs.getStringSet(key, Collections.emptySet());
     }
 
@@ -332,12 +324,15 @@ public class BlockedConversationHelper {
     private static String getBlockedWordOf(SharedPreferences prefs, String value) {
 
         value = value.replaceAll("\\s", " ");
-        final List<String> split = Arrays.asList(value.split(" "));
 
         // NO regex used, utf support for \w, \s, and \b character classes is very clunky.
-
+        final List<String> split = Arrays.asList(value.split(" "));
         for (final String each : getBlockedWords(prefs))
             if (split.contains(each))
+                return each;
+
+        for (final String each : getBlockedWords(prefs))
+            if (value.contains(each))
                 return each;
 
         return null;
@@ -357,12 +352,9 @@ public class BlockedConversationHelper {
         if(compilePattern(value) == null)
             return false;
 
-        final String key = SettingsFragment.BLOCKED_PATTERN;
-        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
-        final boolean modified = values.add(value);
-        prefs.edit().putStringSet(key, values).apply();
-
-        return modified;
+        return modifyCollection(prefs, value,
+                SettingsFragment.BLOCKED_PATTERN,
+                true);
     }
 
     /**
@@ -375,12 +367,9 @@ public class BlockedConversationHelper {
      */
     public static boolean unblockPattern(SharedPreferences prefs, final String value) {
 
-        final String key = SettingsFragment.BLOCKED_PATTERN;
-        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
-        final boolean modified = values.remove(value);
-        prefs.edit().putStringSet(key, values).apply();
-
-        return modified;
+        return modifyCollection(prefs, value,
+                SettingsFragment.BLOCKED_PATTERN,
+                false);
     }
 
     /**
@@ -443,22 +432,16 @@ public class BlockedConversationHelper {
 
     public static boolean blockNumberPrefix(SharedPreferences prefs, final String value) {
 
-        final String key = SettingsFragment.BLOCKED_NUMBER_PREFIX;
-        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
-        final boolean modified = values.add(value);
-        prefs.edit().putStringSet(key, values).apply();
-
-        return modified;
+        return modifyCollection(prefs, value,
+                SettingsFragment.BLOCKED_NUMBER_PREFIX,
+                true);
     }
 
     public static boolean unblockNumberPrefix(SharedPreferences prefs, final String value) {
 
-        final String key = SettingsFragment.BLOCKED_NUMBER_PREFIX;
-        final Set<String> values = prefs.getStringSet(key, new HashSet<String>(0));
-        final boolean modified = values.remove(value);
-        prefs.edit().putStringSet(key, values).apply();
-
-        return modified;
+        return modifyCollection(prefs, value,
+                SettingsFragment.BLOCKED_NUMBER_PREFIX,
+                false);
     }
 
     /**

--- a/QKSMS/src/main/java/com/moez/QKSMS/receiver/MessagingReceiver.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/receiver/MessagingReceiver.java
@@ -104,7 +104,7 @@ public class MessagingReceiver extends BroadcastReceiver {
         // The user has set messages from this address to be blocked, but we at the time there weren't any
         // messages from them already in the database, so we couldn't block any thread URI. Now that we have one,
         // we can block it, so that the conversation list adapter knows to ignore this thread in the main list
-        if (BlockedConversationHelper.isFutureBlocked(mPrefs, mAddress)) {
+        if (BlockedConversationHelper.isBlocked(mPrefs, mContext, message, mAddress, mBody, mDate)) {
             BlockedConversationHelper.unblockFutureConversation(mPrefs, mAddress);
             BlockedConversationHelper.blockConversation(mPrefs, message.getThreadId());
             message.markSeen();

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/BlockedNumberDialog.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/BlockedNumberDialog.java
@@ -1,15 +1,24 @@
 package com.moez.QKSMS.ui.dialog;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.support.annotation.StringRes;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import com.moez.QKSMS.R;
 import com.moez.QKSMS.common.BlockedConversationHelper;
+import com.moez.QKSMS.common.utils.PhoneNumberUtils;
 import com.moez.QKSMS.ui.base.QKActivity;
 import com.moez.QKSMS.ui.view.QKEditText;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public class BlockedNumberDialog {
@@ -58,6 +67,140 @@ public class BlockedNumberDialog {
                                 .show();
                     }
                 })
+                .setNegativeButton(R.string.cancel, null)
+                .show();
+    }
+
+    public static void showNumbersDialog(final QKActivity context) {
+
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        makeDialog(
+                context,
+                R.string.title_block_address,
+                R.string.pref_block_future,
+                BlockedConversationHelper.getFutureBlockedConversations(prefs),
+                value -> BlockedConversationHelper.blockFutureConversation(prefs, value),
+                value -> BlockedConversationHelper.unblockFutureConversation(prefs, value),
+                value -> true
+        );
+    }
+
+    public static void showPatternsDialog(final QKActivity context) {
+
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        makeDialog(
+                context,
+                R.string.title_block_pattern,
+                R.string.pref_block_pattern,
+                BlockedConversationHelper.getBlockedPatterns(prefs),
+                value -> BlockedConversationHelper.blockPattern(prefs, value),
+                value -> BlockedConversationHelper.unblockPattern(prefs, value),
+                value -> {
+                    if (BlockedConversationHelper.compilePattern(value) != null)
+                        return true;
+                    toast(context, R.string.invalid_pattern);
+                    return false;
+                }
+        );
+    }
+
+    public static void showWordsDialog(final QKActivity context) {
+
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        makeDialog(
+                context,
+                R.string.title_block_word,
+                R.string.pref_block_word,
+                BlockedConversationHelper.getBlockedWords(prefs),
+                value -> BlockedConversationHelper.blockWord(prefs, value),
+                value -> BlockedConversationHelper.unblockWord(prefs, value),
+                value -> true
+        );
+    }
+
+    public static void showNumberPrefixDialog(final QKActivity context) {
+
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        makeDialog(
+                context,
+                R.string.title_block_number_prefix,
+                R.string.pref_block_number_prefix,
+                BlockedConversationHelper.getBlockedNumberPrefixes(prefs),
+                value -> BlockedConversationHelper.blockNumberPrefix(prefs, value),
+                value -> BlockedConversationHelper.unblockNumberPrefix(prefs, value),
+                value -> {
+                    if (!PhoneNumberUtils.isWellFormedSmsAddress(value))
+                        toast(context, R.string.invalid_number_prefix);
+                    return true;
+                }
+        );
+    }
+
+
+    // TODO add a Function<T, R> interface, it's useful.
+    // TODO is it ok to add guava dependency? if so it has the interface already.
+    // java.util.function isn't available in android's sdk (java 7).
+    private interface ValueProcessor {
+        boolean apply(String value);
+    }
+
+    private static void toast(final Context context, @StringRes final int msg) {
+
+        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
+    }
+
+    private static void makeDialog(final QKActivity context,
+                                   @StringRes final int addDialogTitle,
+                                   @StringRes final int parentDialogTitle,
+                                   final Collection<String> values,
+                                   final ValueProcessor adder,
+                                   final ValueProcessor remover,
+                                   final ValueProcessor validator) {
+
+        final List<String> values_ = new ArrayList<>(values);
+        Collections.sort(values_);
+
+        final QKDialog parentDialog = new QKDialog();
+        final QKDialog addDialog = new QKDialog();
+
+        final AdapterView.OnItemClickListener onItemClick = (parent, view, position, id) -> {
+            final CharSequence userInput = ((TextView) view).getText();
+            final String value = userInput == null ? "" : userInput.toString();
+            final boolean changed = remover.apply(value);
+            if (changed) {
+                values_.remove(value);
+                parentDialog.getListAdapter().notifyDataSetChanged();
+            }
+        };
+
+        final View.OnClickListener onAdd = view -> {
+            final QKEditText text = new QKEditText(context);
+            addDialog.setContext(context)
+                    .setTitle(addDialogTitle)
+                    .setCustomView(text)
+                    .setPositiveButton(R.string.add, v -> {
+                        final CharSequence userInput = ((TextView) text).getText();
+                        final String value = userInput == null ? "" : userInput.toString();
+                        if (value.isEmpty() || !validator.apply(value))
+                            return;
+                        final boolean changed = adder.apply(value);
+                        if (changed) {
+                            values_.add(value);
+                            parentDialog.getListAdapter().notifyDataSetChanged();
+                        }
+                    })
+                    .setNegativeButton(R.string.cancel, null)
+                    .show();
+        };
+
+        parentDialog.setContext(context)
+                .setTitle(parentDialogTitle)
+                .setItems(false, values_, onItemClick)
+                .setPositiveButton(false, R.string.add, onAdd)
                 .setNegativeButton(R.string.cancel, null)
                 .show();
     }

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/BlockedNumberDialog.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/BlockedNumberDialog.java
@@ -114,9 +114,24 @@ public class BlockedNumberDialog {
                 context,
                 R.string.title_block_word,
                 R.string.pref_block_word,
-                BlockedConversationHelper.getBlockedWords(prefs),
-                value -> BlockedConversationHelper.blockWord(prefs, value),
-                value -> BlockedConversationHelper.unblockWord(prefs, value),
+                BlockedConversationHelper.getBlockedWords(prefs, false),
+                value -> BlockedConversationHelper.blockWord(prefs, value, false),
+                value -> BlockedConversationHelper.unblockWord(prefs, value, false),
+                value -> true
+        );
+    }
+
+    public static void showExtremeWordsDialog(final QKActivity context) {
+
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        makeDialog(
+                context,
+                R.string.title_block_word_extreme,
+                R.string.pref_block_word_extreme,
+                BlockedConversationHelper.getBlockedWords(prefs, true),
+                value -> BlockedConversationHelper.blockWord(prefs, value, true),
+                value -> BlockedConversationHelper.unblockWord(prefs, value, true),
                 value -> true
         );
     }

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/QKDialog.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/dialog/QKDialog.java
@@ -33,6 +33,8 @@ import com.moez.QKSMS.ui.base.QKActivity;
 import com.moez.QKSMS.ui.view.QKTextView;
 
 import java.util.ArrayList;
+import java.util.List;
+
 
 public class QKDialog extends DialogFragment {
     private final String TAG = "QKDialog";
@@ -51,6 +53,8 @@ public class QKDialog extends DialogFragment {
     private QKTextView mMessageView;
 
     private LinearLayout mCustomPanel;
+
+    private ArrayAdapter mAdapter;
 
     private boolean mCustomViewEnabled;
     private View mCustomView;
@@ -257,9 +261,9 @@ public class QKDialog extends DialogFragment {
     }
 
     public QKDialog setItems(String[] items, final OnItemClickListener onClickListener) {
-        ArrayAdapter adapter = new ArrayAdapter<>(mContext, R.layout.list_item_simple, items);
+        mAdapter = new ArrayAdapter<>(mContext, R.layout.list_item_simple, items);
         ListView listView = new ListView(mContext);
-        listView.setAdapter(adapter);
+        listView.setAdapter(mAdapter);
         listView.setDivider(null);
         listView.setPadding(0, Units.dpToPx(mContext, 8), 0, Units.dpToPx(mContext, 8));
         listView.setOnItemClickListener(new OnItemClickListener() {
@@ -272,6 +276,35 @@ public class QKDialog extends DialogFragment {
             }
         });
         return setCustomView(listView);
+    }
+
+    public QKDialog setItems(boolean dismiss,
+                             List<String> items,
+                             final OnItemClickListener onClickListener) {
+        mAdapter = new ArrayAdapter<>(mContext, R.layout.list_item_simple, items);
+        ListView listView = new ListView(mContext);
+        listView.setAdapter(mAdapter);
+        listView.setDivider(null);
+        listView.setPadding(0, Units.dpToPx(mContext, 8), 0, Units.dpToPx(mContext, 8));
+        listView.setOnItemClickListener(new OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent,
+                                    View view,
+                                    int position,
+                                    long id) {
+                if (onClickListener != null) {
+                    onClickListener.onItemClick(parent, view, position, id);
+                    if (dismiss)
+                        dismiss();
+                }
+            }
+        });
+        return setCustomView(listView);
+    }
+
+    public ArrayAdapter getListAdapter() {
+
+        return mAdapter;
     }
 
     public QKDialog setDoubleLineItems(int titles, int bodies, final OnItemClickListener onClickListener) {
@@ -342,6 +375,14 @@ public class QKDialog extends DialogFragment {
     }
 
     public QKDialog setPositiveButton(String text, final OnClickListener onClickListener) {
+        return setPositiveButton(true, text, onClickListener);
+    }
+
+    public QKDialog setPositiveButton(boolean dismiss, int title, final OnClickListener onClickListener) {
+        return setPositiveButton(dismiss, mResources.getString(title), onClickListener);
+    }
+
+    public QKDialog setPositiveButton(boolean dismiss, String text, final OnClickListener onClickListener) {
         mPositiveButtonEnabled = true;
         mPositiveButtonText = text;
         mPositiveButtonClickListener = new OnClickListener() {
@@ -349,8 +390,9 @@ public class QKDialog extends DialogFragment {
             public void onClick(View v) {
                 if (onClickListener != null) {
                     onClickListener.onClick(v);
+                    if (dismiss)
+                        dismiss();
                 }
-                dismiss();
             }
         };
         return this;
@@ -476,3 +518,4 @@ public class QKDialog extends DialogFragment {
         super.show(manager, tag);
     }
 }
+

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsFragment.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsFragment.java
@@ -161,6 +161,7 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
     public static final String BLOCK_SKIP_CONTACTS = "pref_key_block_skip_contact";
     public static final String BLOCKED_PATTERN = "pref_key_block_pattern";
     public static final String BLOCKED_WORD = "pref_key_block_word";
+    public static final String BLOCKED_WORD_EXTREME = "pref_key_block_word_extreme";
     public static final String BLOCKED_NUMBER_PREFIX = "pref_key_block_number_prefix";
 
     public static final String WELCOME_SEEN = "pref_key_welcome_seen";
@@ -599,6 +600,9 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
                 break;
             case BLOCKED_WORD:
                 BlockedNumberDialog.showWordsDialog(mContext);
+                break;
+            case BLOCKED_WORD_EXTREME:
+                BlockedNumberDialog.showExtremeWordsDialog(mContext);
                 break;
             case SHOULD_I_ANSWER:
                 final String packageName = "org.mistergroup.muzutozvednout";

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsFragment.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsFragment.java
@@ -157,6 +157,12 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
     public static final String GITHUB = "pref_key_github";
     public static final String CROWDIN = "pref_key_crowdin";
 
+    public static final String BLOCK_ENABLED = "pref_key_blocked_enabled";
+    public static final String BLOCK_SKIP_CONTACTS = "pref_key_block_skip_contact";
+    public static final String BLOCKED_PATTERN = "pref_key_block_pattern";
+    public static final String BLOCKED_WORD = "pref_key_block_word";
+    public static final String BLOCKED_NUMBER_PREFIX = "pref_key_block_number_prefix";
+
     public static final String WELCOME_SEEN = "pref_key_welcome_seen";
 
     public static final String DEFAULT_NOTIFICATION_TONE = "content://settings/system/notification_sound";

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsFragment.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/settings/SettingsFragment.java
@@ -591,6 +591,15 @@ public class SettingsFragment extends PreferenceFragment implements Preference.O
             case BLOCKED_FUTURE:
                 BlockedNumberDialog.showDialog(mContext);
                 break;
+            case BLOCKED_NUMBER_PREFIX:
+                BlockedNumberDialog.showNumberPrefixDialog(mContext);
+                break;
+            case BLOCKED_PATTERN:
+                BlockedNumberDialog.showPatternsDialog(mContext);
+                break;
+            case BLOCKED_WORD:
+                BlockedNumberDialog.showWordsDialog(mContext);
+                break;
             case SHOULD_I_ANSWER:
                 final String packageName = "org.mistergroup.muzutozvednout";
                 if (!PackageUtils.isAppInstalled(mContext, packageName)) {

--- a/QKSMS/src/main/res/values/strings.xml
+++ b/QKSMS/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@
     <string name="pref_blocked_conversations_summary">Long-press on a conversation and block to move to blocked inbox and stop notifications</string>
     <string name="pref_block_future">Block future messages</string>
     <string name="pref_block_future_summary">Add additional phone numbers to block</string>
+
     <string name="pref_should_i_answer">Should I Answer? Integration</string>
     <string name="pref_should_i_answer_summary">Automatically delete incoming messages from numbers which are blocked through Should I Answer?</string>
     <string name="pref_mobile_only">Mobile numbers</string>
@@ -749,6 +750,26 @@
     <string name="date_just_now">Just now</string>
     <string name="compose_loading_attachment">Loading attachment</string>
     <string name="hint_no_messages">No messages yet.\nClick the + to send one!</string>
+
+
+    <string name="title_block_pattern">Block a pattern</string>
+    <string name="title_unblock_pattern">Unblock regex pattern</string>
+    <string name="pref_block_pattern">Patterns (Advanced!)</string>
+    <string name="pref_block_pattern_summary">Add more regex patterns to blacklist. Follows java regex rules. Click on an item to remove (advanced users only!)</string>
+    <string name="invalid_pattern">Invalid pattern! pattern must follow java regex rules.</string>
+    <string name="title_block_word">Blacklist a word</string>
+    <string name="title_unblock_word">Un-Blacklist word</string>
+    <string name="pref_block_word">Blacklist Words</string>
+    <string name="pref_block_word_summary">Add more words to blacklist. Click on an item to remove. Don\'t forget to add spaces around your words if necessary!</string>
+    <string name="pref_block_skip_contact">Never block contacts</string>
+    <string name="pref_block_skip_contact_summary">Never block messages when they are received from known contacts</string>
+
+
+    <string name="title_block_number_prefix">Block a number prefix</string>
+    <string name="title_unblock_number_prefix">Unblock number prefix</string>
+    <string name="pref_block_number_prefix">Block number prefix</string>
+    <string name="pref_block_number_prefix_summary">Add more number prefixes to blacklist. Click on an item to remove. Any message received from a number whose prefix is in this list is blocked.</string>
+    <string name="invalid_number_prefix">Invalid number prefix! number prefix was added to the list but does not seem to be a valid number.</string>
 
     <string-array name="resend_menu">
         <item>Resend</item>

--- a/QKSMS/src/main/res/values/strings.xml
+++ b/QKSMS/src/main/res/values/strings.xml
@@ -759,8 +759,12 @@
     <string name="invalid_pattern">Invalid pattern! pattern must follow java regex rules.</string>
     <string name="title_block_word">Blacklist a word</string>
     <string name="title_unblock_word">Un-Blacklist word</string>
-    <string name="pref_block_word">Blacklist Words</string>
-    <string name="pref_block_word_summary">Add more words to blacklist. Click on an item to remove. Don\'t forget to add spaces around your words if necessary!</string>
+    <string name="title_block_word_extreme">Blacklist a word (Extreme)</string>
+    <string name="title_unblock_word_extreme">Un-Blacklist word (Extreme)</string>
+    <string name="pref_block_word">Blacklist Words (Safe)</string>
+    <string name="pref_block_word_summary">Add more words to blacklist. Click on an item to remove.</string>
+    <string name="pref_block_word_extreme">Blacklist Words (Extreme)</string>
+    <string name="pref_block_word_extreme_summary">Add more words to blacklist. does NOT check word boundary.</string>
     <string name="pref_block_skip_contact">Never block contacts</string>
     <string name="pref_block_skip_contact_summary">Never block messages when they are received from known contacts</string>
 

--- a/QKSMS/src/main/res/xml/settings_general.xml
+++ b/QKSMS/src/main/res/xml/settings_general.xml
@@ -136,6 +136,34 @@
             android:summary="@string/pref_should_i_answer_summary"
             android:title="@string/pref_should_i_answer"
             android:widgetLayout="@layout/view_switch" />
+        <Preference
+            android:defaultValue="false"
+            android:dependency="pref_key_blocked_enabled"
+            android:key="pref_key_block_pattern"
+            android:layout="@layout/list_item_preference"
+            android:summary="@string/pref_block_pattern_summary"
+            android:title="@string/pref_block_pattern" />
+        <Preference
+            android:defaultValue="false"
+            android:dependency="pref_key_blocked_enabled"
+            android:key="pref_key_block_word"
+            android:layout="@layout/list_item_preference"
+            android:summary="@string/pref_block_word_summary"
+            android:title="@string/pref_block_word" />
+        <Preference
+            android:defaultValue="false"
+            android:dependency="pref_key_blocked_enabled"
+            android:key="pref_key_block_number_prefix"
+            android:layout="@layout/list_item_preference"
+            android:summary="@string/pref_block_number_prefix_summary"
+            android:title="@string/pref_block_number_prefix" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_key_block_skip_contact"
+            android:layout="@layout/list_item_preference"
+            android:summary="@string/pref_block_skip_contact_summary"
+            android:title="@string/pref_block_skip_contact"
+            android:widgetLayout="@layout/view_switch" />
     </PreferenceCategory>
     <PreferenceCategory
         android:layout="@layout/list_item_preference_category"

--- a/QKSMS/src/main/res/xml/settings_general.xml
+++ b/QKSMS/src/main/res/xml/settings_general.xml
@@ -153,6 +153,13 @@
         <Preference
             android:defaultValue="false"
             android:dependency="pref_key_blocked_enabled"
+            android:key="pref_key_block_word_extreme"
+            android:layout="@layout/list_item_preference"
+            android:summary="@string/pref_block_word_extreme_summary"
+            android:title="@string/pref_block_word_extreme" />
+        <Preference
+            android:defaultValue="false"
+            android:dependency="pref_key_blocked_enabled"
             android:key="pref_key_block_number_prefix"
             android:layout="@layout/list_item_preference"
             android:summary="@string/pref_block_number_prefix_summary"


### PR DESCRIPTION
This commit lets user specify some words as spam. later if a message contains such word that number is automatically blocked.

It's also possible to block messages by number prefix, say 343. Later all the 343* numbers are blocked (343123, 343111, 3431, ...)

And Java regex is also supported. For instance it's possible to block `pay \d\d.*!` so "pay 99 cents!" is blocked but "pay your debt tomorrow!" is not.

A little change is made in QKDialog. It can be set to that the list wont be dismissed after an item is added/removed (by default it would, as before). Also the list adapter is accessible from outside, so `notifyDataSetChanged()` can be called in case list data is modified outside of the list. This is used in the list of adding, removing number prefixes, spam words and patterns.