### PR TITLE
Keyboard does not hide fast enough when the back button is pressed #937

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/search/SearchActivity.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/search/SearchActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import com.moez.QKSMS.R;
+import com.moez.QKSMS.common.utils.KeyboardUtils;
 import com.moez.QKSMS.ui.base.QKSwipeBackActivity;
 
 public class SearchActivity extends QKSwipeBackActivity {
@@ -31,5 +32,11 @@ public class SearchActivity extends QKSwipeBackActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         new MenuInflater(this).inflate(R.menu.search, menu);
         return super.onCreateOptionsMenu(menu);
+    }
+    
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        KeyboardUtils.hide(this);
     }
 }


### PR DESCRIPTION
Hi @moezbhatti 

I have resolved the bug related to issue #937 .
I have added the code to close the keyboard right after the back arrow is clicked. This made the animation much smother in my opinion. Plus the keyboard does not hang in the parent view as long as it used to. 
Let me know if the fix is good to be accepted, so that i could possible implement the same strategy in other activities that have same issue. 