### PR TITLE
Search conversation snippets as well as recipients

### DIFF
--- a/presentation/src/main/java/common/util/filter/ConversationFilter.kt
+++ b/presentation/src/main/java/common/util/filter/ConversationFilter.kt
@@ -24,7 +24,11 @@ import javax.inject.Inject
 class ConversationFilter @Inject constructor(private val recipientFilter: RecipientFilter) : Filter<Conversation>() {
 
     override fun filter(item: Conversation, query: CharSequence): Boolean {
-        return item.recipients.any { recipient -> recipientFilter.filter(recipient, query) }
+        return item.recipients.any { recipient -> recipientFilter.filter(recipient, query) } ||
+                if (query.matches(Regex("/.*/")))
+                    Regex(query.trim('/').toString()).containsMatchIn(item.snippet)
+                else
+                    item.snippet.contains(query)
     }
 
 }


### PR DESCRIPTION
This PR makes the search match the contents of the snippet, and additionally allows searching with regular expressions. If a search query is surrounded by `/`, it searches via regular expression. Otherwise, it does a standard text search.

The regex search isn't very discoverable, so perhaps it should be advertised somehow.

![screenshot_1524690632](https://user-images.githubusercontent.com/4571394/39273633-6500f4d4-48ad-11e8-944f-c8ec363fa0c4.png)
![screenshot_1524690685](https://user-images.githubusercontent.com/4571394/39273635-65291356-48ad-11e8-8ca6-3da1dbc61f58.png)
![screenshot_1524691231](https://user-images.githubusercontent.com/4571394/39273636-654deab4-48ad-11e8-95d0-9853db9bbcd3.png)
