### PR TITLE
Prevent crash on sending SMS when SEND_SMS is not granted

### DIFF
--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -112,6 +112,8 @@
     <string name="settings_vibration_title">Vibration</string>
     <string name="settings_ringtone_title">Sound</string>
     <string name="settings_blocking_title">Blocking</string>
+
+    <string name="error_sms_permissions">Couldn\'t send SMS due to lack of permission</string>
     <!-- Do not translate -->
     <string name="settings_should_i_answer_title">Should I Answer?</string>
     <string name="settings_should_i_answer_summary">Automatically filter messages from unsolicited numbers by using the \"Should I Answer\" app</string>


### PR DESCRIPTION
Previously, if the SEND_SMS permission wasn't granted, the application would crash. Now, it shows a toast explaining the issue.

I've found that it's possible to bypass the splash screen without granting the appropriate permissions, but ensuring there's no way one can see a `ComposeActivity` without having the permission would also be an appropriate fix to this.