### PR TITLE
Fix margin end in toolbarSearch

### DIFF
--- a/presentation/src/main/res/layout/main_activity.xml
+++ b/presentation/src/main/res/layout/main_activity.xml
@@ -46,6 +46,7 @@
             <common.widget.QkEditText
                 android:id="@+id/toolbarSearch"
                 style="@style/ToolbarText"
+                android:layout_marginEnd="16dp"
                 android:hint="@string/title_conversations"
                 android:textColorHint="?android:attr/textColorTertiary"
                 app:textSize="primary"


### PR DESCRIPTION
This looks very bad especially in RTL languages.


<img width="371" alt="screen shot 2018-06-18 at 6 08 14 pm" src="https://user-images.githubusercontent.com/6718541/41539504-2d2c029c-7323-11e8-81c8-3cc86a7134f1.png">
<img width="371" alt="screen shot 2018-06-18 at 6 07 36 pm" src="https://user-images.githubusercontent.com/6718541/41539533-369af572-7323-11e8-9a9f-3a545c8b1ca6.png">