### PR TITLE
fix#1203 enable search with non-ascii characters

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/extensions/StringExtensions.kt
+++ b/data/src/main/java/com/moez/QKSMS/extensions/StringExtensions.kt
@@ -24,4 +24,3 @@ import java.text.Normalizer
  * Strip the accents from a string
  */
 fun CharSequence.removeAccents() = Normalizer.normalize(this, Normalizer.Form.NFD)
-        .replace(Regex("[^\\p{ASCII}]"), "")


### PR DESCRIPTION
you can only search contacts and message content with ascii characters. When entering Chinese or Japannese characters, filter will not work beacuse _CharSequence.removeAccents()_ will remove all non-ascii characters.