### PR TITLE
Use longer sms length when not using diacritics

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -528,7 +528,7 @@ class ComposeViewModel @Inject constructor(
         // Show the remaining character counter when necessary
         view.textChangedIntent
                 .observeOn(Schedulers.computation())
-                .mapNotNull { draft -> tryOrNull { SmsMessage.calculateLength(draft, false) } }
+                .mapNotNull { draft -> tryOrNull { SmsMessage.calculateLength(draft, prefs.unicode.get()) } }
                 .map { array ->
                     val messages = array[0]
                     val remaining = array[2]


### PR DESCRIPTION
I noticed that even when I check "Remove diacritics" (not sure if that is what the setting is called in english) the app counts with the lower max character count for a single SMS. This fixes the problem.