### PR TITLE
Fix crash on opening Conversation caused by Substratum SystemUI theming

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ContextExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ContextExtensions.kt
@@ -20,23 +20,17 @@ package com.moez.QKSMS.common.util.extensions
 
 import android.app.Activity
 import android.content.Context
-import android.content.res.Resources
 import android.graphics.Color
-import android.util.Log
 import android.util.TypedValue
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
-import com.moez.QKSMS.common.util.BugsnagTree
+import com.moez.QKSMS.util.tryOrNull
 
 fun Context.getColorCompat(colorRes: Int): Int {
-    return try {
-        ContextCompat.getColor(this, colorRes)
-    } catch (e: Resources.NotFoundException) {
-        BugsnagTree().log(Log.ERROR, e)
-        Color.BLACK
-    }
+    //return black as a default color, in case an invalid color ID was passed in
+    return tryOrNull { ContextCompat.getColor(this, colorRes) } ?: Color.BLACK
 }
 
 /**

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ContextExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ContextExtensions.kt
@@ -20,14 +20,23 @@ package com.moez.QKSMS.common.util.extensions
 
 import android.app.Activity
 import android.content.Context
+import android.content.res.Resources
+import android.graphics.Color
+import android.util.Log
 import android.util.TypedValue
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
+import com.moez.QKSMS.common.util.BugsnagTree
 
 fun Context.getColorCompat(colorRes: Int): Int {
-    return ContextCompat.getColor(this, colorRes)
+    return try {
+        ContextCompat.getColor(this, colorRes)
+    } catch (e: Resources.NotFoundException) {
+        BugsnagTree().log(Log.ERROR, e)
+        Color.BLACK
+    }
 }
 
 /**


### PR DESCRIPTION
Workaround for crash caused by Substratum theming of SystemUI where opening a text conversation causes the app to crash because the Color Resource ID is set to 0 (an invalid ID)

Instead of crashing, log an error and return a default color

Issue and fix tested on Moto X Pure on Android N 7.1.2 - Resurrection Remix ROM, using Spectrum Theme for SystemUI with Substratum