### PR TITLE
Fix visibility of sim view for multi-sim devices

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -180,7 +180,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         toolbarTitle.setVisible(!state.editingMode)
         chips.setVisible(state.editingMode)
         contacts.setVisible(state.contactsVisible)
-        composeBar.setVisible(!state.contactsVisible && !state.loading)
+        composeBar.setVisible(state.shouldShowComposeBar())
 
         // Don't set the adapters unless needed
         if (state.editingMode && chips.adapter == null) chips.adapter = chipsAdapter
@@ -224,13 +224,18 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         counter.text = state.remaining
         counter.setVisible(counter.text.isNotBlank())
 
-        sim.setVisible(state.subscription != null)
+        // for dual/ multi-sim devices the visibility of the sim view should also behave like composeBar, which hides when the contacts list is visible
+        // of if it's loading state.
+        sim.setVisible(state.subscription != null && state.shouldShowComposeBar())
         sim.contentDescription = getString(R.string.compose_sim_cd, state.subscription?.displayName)
         simIndex.text = "${state.subscription?.simSlotIndex?.plus(1)}"
 
         send.isEnabled = state.canSend
         send.imageAlpha = if (state.canSend) 255 else 128
     }
+
+    // we should show the compose bar only if the contacts list is not visible and the current state is not loading.
+    private fun ComposeState.shouldShowComposeBar(): Boolean = !contactsVisible && !loading
 
     override fun clearSelection() {
         messageAdapter.clearSelection()


### PR DESCRIPTION
## Prerequisites
Use QKSms on a dual/ multi-sim device.

### Steps to reproduce
* Go to `ComposeActivity` 
* Search for a contact
* Observe the visibility of the `sim` view at bottom. 

### Fixes by
* Having the same behaviour as `composeBar` as an add-on visibility check for the `sim` view. 
