### PR TITLE
Fix build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ buildscript {
     ext.rxkotlin_version = '2.1.0'
     ext.rx_preferences_version = '2.0.0-RC3'
     ext.timber_version = '4.5.1'
+    ext.okhttp3_version = '4.1.0'
 
     ext.abiCodes = ['armeabi-v7a': 1, 'arm64-v8a': 2]
 

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     implementation "com.f2prateek.rx.preferences2:rx-preferences:$rx_preferences_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation "com.squareup.moshi:moshi:$moshi_version"
+    implementation "com.squareup.okhttp3:okhttp:$okhttp3_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation project(":android-smsmms")

--- a/data/src/main/java/com/moez/QKSMS/repository/BackupRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/BackupRepositoryImpl.kt
@@ -33,7 +33,8 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 import io.realm.Realm
-import okio.Okio
+import okio.buffer
+import okio.source
 import timber.log.Timber
 import java.io.File
 import java.io.FileOutputStream
@@ -158,7 +159,7 @@ class BackupRepositoryImpl @Inject constructor(
                 files.mapNotNull { file ->
                     val adapter = moshi.adapter(BackupMetadata::class.java)
                     val backup = tryOrNull(false) {
-                        Okio.buffer(Okio.source(file)).use(adapter::fromJson)
+                        file.source().buffer().use(adapter::fromJson)
                     } ?: return@mapNotNull null
 
                     val path = file.path
@@ -177,7 +178,7 @@ class BackupRepositoryImpl @Inject constructor(
         restoreProgress.onNext(BackupRepository.Progress.Parsing())
 
         val file = File(filePath)
-        val backup = Okio.buffer(Okio.source(file)).use { source ->
+        val backup = file.source().buffer().use { source ->
             moshi.adapter(Backup::class.java).fromJson(source)
         }
 


### PR DESCRIPTION
The `noAnalytics` builds were failing because of missing dependency , the reason they were not appearing in travis tests seems to be 

> dependency is transitively included in one of the withAnalytics libraries

This pull addresses the issue. 

[Tested](https://circleci.com/gh/GeoZac/qksms/7) with both `./gradlew assemblenoAnalyticsDebug` and `./gradlew assemblewithAnalyticsDebug`