### PR TITLE
Use the share intent subject besides the text

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
@@ -55,14 +55,19 @@ class ComposeActivityModule {
     @Provides
     @Named("text")
     fun provideSharedText(activity: ComposeActivity): String {
-        return activity.intent.extras?.getString(Intent.EXTRA_TEXT)
+        var subject = activity.intent.getStringExtra(Intent.EXTRA_SUBJECT) ?: "";
+        if (subject != "") {
+            subject += "\n"
+        }
+
+        return subject + (activity.intent.extras?.getString(Intent.EXTRA_TEXT)
                 ?: activity.intent.extras?.getString("sms_body")
                 ?: activity.intent?.decodedDataString()
                         ?.substringAfter('?') // Query string
                         ?.split(',')
                         ?.firstOrNull { param -> param.startsWith("body") }
                         ?.substringAfter('=')
-                ?: ""
+                ?: "")
     }
 
     @Provides


### PR DESCRIPTION
When sharing a text, some applications also set the subject field in the share intent.
For instance, when sharing a video with NewPipe, the title of the video is put in the subject of the intent.
This change makes use of the subject field when providing the shared text.