### PR TITLE
Fix problem when put whitespace in search inbox.

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -190,6 +190,7 @@ class MainViewModel @Inject constructor(
         view.queryChangedIntent
                 .debounce(200, TimeUnit.MILLISECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
+                .map { query -> query.trim() }
                 .withLatestFrom(state) { query, state ->
                     if (query.isEmpty() && state.page is Searching) {
                         newState { copy(page = Inbox(data = conversationRepo.getConversations())) }
@@ -197,7 +198,6 @@ class MainViewModel @Inject constructor(
                     query
                 }
                 .filter { query -> query.length >= 2 }
-                .map { query -> query.trim() }
                 .distinctUntilChanged()
                 .doOnNext {
                     newState {


### PR DESCRIPTION
For issue  #1776
When you type spaces in search inbox (a blank query), map operator convert the query to an empty query by trim() method. Then app starts searching for an empty query and gets into the not responding state. 
I moved the map operator before withLatestFrom operator, So empty query gets involved in withLatestFrom if statement.   
