### PR TITLE
Include hasFragileUserData flag

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -45,7 +45,8 @@
         android:label="@string/app_name"
         android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
-        android:theme="@style/AppLaunchTheme">
+        android:theme="@style/AppLaunchTheme"
+        android:hasFragileUserData="true">
 
         <activity
             android:name=".feature.main.MainActivity"


### PR DESCRIPTION
This manifest flag lets users choose whether to keep app data when uninstalling the app. Helpful for things like rolling back to previous versions. Pretty harmless to include otherwise. Documentation: https://developer.android.com/guide/topics/manifest/application-element#fragileuserdata