### PR TITLE
Add support for video and audio attachments

### DIFF
--- a/android-smsmms/src/main/java/com/google/android/mms/ContentType.java
+++ b/android-smsmms/src/main/java/com/google/android/mms/ContentType.java
@@ -66,6 +66,7 @@ public class ContentType {
     public static final String AUDIO_3GPP        = "audio/3gpp";
     public static final String AUDIO_X_WAV       = "audio/x-wav";
     public static final String AUDIO_OGG         = "application/ogg";
+    public static final String AUDIO_OGG_ALT     = "audio/ogg";
 
     public static final String VIDEO_UNSPECIFIED = "video/*";
     public static final String VIDEO_3GPP        = "video/3gpp";
@@ -121,6 +122,7 @@ public class ContentType {
         sSupportedContentTypes.add(AUDIO_X_WAV);
         sSupportedContentTypes.add(AUDIO_3GPP);
         sSupportedContentTypes.add(AUDIO_OGG);
+        sSupportedContentTypes.add(AUDIO_OGG_ALT);
 
         sSupportedContentTypes.add(VIDEO_3GPP);
         sSupportedContentTypes.add(VIDEO_3G2);
@@ -165,6 +167,7 @@ public class ContentType {
         sSupportedAudioTypes.add(AUDIO_X_WAV);
         sSupportedAudioTypes.add(AUDIO_3GPP);
         sSupportedAudioTypes.add(AUDIO_OGG);
+        sSupportedAudioTypes.add(AUDIO_OGG_ALT);
 
         // add supported video types
         sSupportedVideoTypes.add(VIDEO_3GPP);

--- a/domain/src/main/java/com/moez/QKSMS/model/Attachment.kt
+++ b/domain/src/main/java/com/moez/QKSMS/model/Attachment.kt
@@ -21,10 +21,10 @@ package com.moez.QKSMS.model
 import android.content.Context
 import android.net.Uri
 import android.os.Build
+import android.provider.OpenableColumns
 import androidx.core.view.inputmethod.InputContentInfoCompat
 
 sealed class Attachment {
-
     data class Image(
         private val uri: Uri? = null,
         private val inputContent: InputContentInfoCompat? = null
@@ -47,8 +47,66 @@ sealed class Attachment {
         }
     }
 
-    data class Contact(val vCard: String) : Attachment()
+    data class Video(
+        private val uri: Uri? = null,
+        private val inputContent: InputContentInfoCompat? = null
+    ) : Attachment() {
+        fun getUri(): Uri? {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+                inputContent?.contentUri ?: uri
+            } else {
+                uri
+            }
+        }
 
+        fun getContentType(context: Context): String? {
+            return getUri()?.let(context.contentResolver::getType)
+        }
+    }
+
+    data class File(
+        private val uri: Uri? = null,
+        private val inputContent: InputContentInfoCompat? = null
+    ) : Attachment() {
+
+        fun getUri(): Uri? {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+                inputContent?.contentUri ?: uri
+            } else {
+                uri
+            }
+        }
+
+        fun getContentType(context: Context): String? {
+            return getUri()?.let(context.contentResolver::getType)
+        }
+
+        fun getName(context: Context): String? {
+            return getUri()?.let {
+                // The selection parameter can be null since the intent only opens one file.
+                returnUri ->
+                context.contentResolver.query(returnUri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            }?.use { cursor ->
+                val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                cursor.moveToFirst()
+                return cursor.getString(nameIndex)
+            }
+        }
+
+        fun getSize(context: Context): Long? {
+            return getUri()?.let {
+                // The selection parameter can be null since the intent only opens one file.
+                returnUri ->
+                context.contentResolver.query(returnUri, arrayOf(OpenableColumns.SIZE), null, null, null)
+            }?.use { cursor ->
+                val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+                cursor.moveToFirst()
+                return cursor.getLong(sizeIndex)
+            }
+        }
+    }
+
+    data class Contact(val vCard: String) : Attachment()
 }
 
 class Attachments(attachments: List<Attachment>) : List<Attachment> by attachments

--- a/domain/src/main/java/com/moez/QKSMS/model/MmsPart.kt
+++ b/domain/src/main/java/com/moez/QKSMS/model/MmsPart.kt
@@ -44,6 +44,7 @@ open class MmsPart : RealmObject() {
         type == "text/x-vCard" -> "Contact card"
         type.startsWith("image") -> "Photo"
         type.startsWith("video") -> "Video"
+        type.startsWith("audio") -> "Audio"
         else -> null
     }
 

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -95,6 +95,26 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/x-vcard" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
 
             <meta-data
                 android:name="android.service.chooser.chooser_target_service"

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
@@ -91,6 +91,14 @@ class ComposeActivityModule {
                     text?.let(Attachment::Contact)
                 }
 
+                ContentType.isVideoType(mimeType) -> {
+                    Attachment.Video(uri)
+                }
+
+                ContentType.isSupportedType(mimeType) -> {
+                    Attachment.File(uri)
+                }
+
                 else -> null
             }
         })

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -46,8 +46,12 @@ interface ComposeView : QkView<ComposeState> {
     val galleryIntent: Observable<*>
     val scheduleIntent: Observable<*>
     val attachContactIntent: Observable<*>
+    val attachAudioIntent: Observable<*>
+    val attachVideoIntent: Observable<*>
     val attachmentSelectedIntent: Observable<Uri>
     val contactSelectedIntent: Observable<Uri>
+    val audioSelectedIntent: Observable<Uri>
+    val videoSelectedIntent: Observable<Uri>
     val inputContentIntent: Observable<InputContentInfoCompat>
     val scheduleSelectedIntent: Observable<Long>
     val scheduleCancelIntent: Observable<*>
@@ -66,6 +70,8 @@ interface ComposeView : QkView<ComposeState> {
     fun showKeyboard()
     fun requestCamera()
     fun requestGallery()
+    fun requestAudio()
+    fun requestVideo()
     fun requestDatePicker()
     fun requestContact()
     fun setDraft(draft: String)

--- a/presentation/src/main/res/drawable/ic_audiotrack_black_24dp.xml
+++ b/presentation/src/main/res/drawable/ic_audiotrack_black_24dp.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (C) 2023 Moez Bhatti <moez.bhatti@gmail.com>
+  ~
+  ~ This file is part of QKSMS.
+  ~
+  ~ QKSMS is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ QKSMS is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,3v9.28c-0.47,-0.17 -0.97,-0.28 -1.5,-0.28C8.01,12 6,14.01 6,16.5S8.01,21 10.5,21c2.31,0 4.2,-1.75 4.45,-4H15V6h4V3h-7z"/>
+</vector>

--- a/presentation/src/main/res/layout/attachment_file_list_item.xml
+++ b/presentation/src/main/res/layout/attachment_file_list_item.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2019 Moez Bhatti <moez.bhatti@gmail.com>
+  ~
+  ~ This file is part of QKSMS.
+  ~
+  ~ QKSMS is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ QKSMS is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    tools:background="?attr/bubbleColor">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="56dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="8dp"
+        android:background="@drawable/rounded_rectangle_outline_4dp"
+        android:backgroundTint="?android:attr/divider"
+        android:paddingEnd="8dp">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="16dp"
+            android:src="@drawable/ic_attachment_black_24dp"
+            android:tint="?android:attr/textColorSecondary"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.moez.QKSMS.common.widget.QkTextView
+            android:id="@+id/filename"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:textColor="?android:attr/textColorPrimary"
+            app:layout_constraintBottom_toTopOf="@id/size"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
+            app:textSize="primary"
+            tools:text="Resume.pdf" />
+
+        <com.moez.QKSMS.common.widget.QkTextView
+            android:id="@+id/size"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:textColor="?android:attr/textColorTertiary"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toBottomOf="@id/filename"
+            app:textSize="secondary" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <ImageView
+        android:id="@+id/detach"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="top|end"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="2dp"
+        android:background="@drawable/circle"
+        android:backgroundTint="?attr/bubbleColor"
+        android:src="@drawable/ic_cancel_black_24dp"
+        android:tint="?android:attr/textColorSecondary" />
+
+</FrameLayout>

--- a/presentation/src/main/res/layout/compose_activity.xml
+++ b/presentation/src/main/res/layout/compose_activity.xml
@@ -367,7 +367,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:constraint_referenced_ids="contact,contactLabel,schedule,scheduleLabel,gallery,galleryLabel,camera,cameraLabel,attachingBackground" />
+        app:constraint_referenced_ids="contact,contactLabel,schedule,scheduleLabel,gallery,galleryLabel,camera,cameraLabel,attachingBackground,audio,audioLabel,video,videoLabel" />
 
     <View
         android:id="@+id/attachingBackground"
@@ -495,7 +495,7 @@
         android:src="@drawable/ic_camera_alt_black_24dp"
         android:tint="?android:attr/textColorSecondary"
         android:visibility="visible"
-        app:layout_constraintBottom_toTopOf="@id/attach"
+        app:layout_constraintBottom_toTopOf="@id/audio"
         app:layout_constraintEnd_toEndOf="@id/attach"
         app:layout_constraintStart_toStartOf="@id/attach" />
 
@@ -515,6 +515,74 @@
         app:layout_constraintBottom_toBottomOf="@id/camera"
         app:layout_constraintStart_toEndOf="@id/gallery"
         app:layout_constraintTop_toTopOf="@id/camera" />
+
+    <ImageView
+        android:id="@+id/audio"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginBottom="16dp"
+        android:background="@drawable/circle"
+        android:backgroundTint="?attr/bubbleColor"
+        android:contentDescription="@string/compose_audio_cd"
+        android:elevation="4dp"
+        android:padding="10dp"
+        android:src="@drawable/ic_audiotrack_black_24dp"
+        android:tint="?android:attr/textColorSecondary"
+        android:visibility="visible"
+        app:layout_constraintBottom_toTopOf="@id/video"
+        app:layout_constraintEnd_toEndOf="@id/attach"
+        app:layout_constraintStart_toStartOf="@id/attach" />
+
+    <com.moez.QKSMS.common.widget.QkTextView
+        android:id="@+id/audioLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/rounded_rectangle_4dp"
+        android:backgroundTint="?attr/bubbleColor"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:text="@string/compose_audio_cd"
+        android:textColor="?android:attr/textColorPrimary"
+        app:layout_constraintBottom_toBottomOf="@id/audio"
+        app:layout_constraintStart_toEndOf="@id/gallery"
+        app:layout_constraintTop_toTopOf="@id/audio" />
+
+    <ImageView
+        android:id="@+id/video"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginBottom="16dp"
+        android:background="@drawable/circle"
+        android:backgroundTint="?attr/bubbleColor"
+        android:contentDescription="@string/compose_video_cd"
+        android:elevation="4dp"
+        android:padding="10dp"
+        android:src="@drawable/ic_play_circle_filled_white_24dp"
+        android:tint="?android:attr/textColorSecondary"
+        android:visibility="visible"
+        app:layout_constraintBottom_toTopOf="@id/attach"
+        app:layout_constraintEnd_toEndOf="@id/attach"
+        app:layout_constraintStart_toStartOf="@id/attach" />
+
+    <com.moez.QKSMS.common.widget.QkTextView
+        android:id="@+id/videoLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/rounded_rectangle_4dp"
+        android:backgroundTint="?attr/bubbleColor"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:text="@string/compose_video_cd"
+        android:textColor="?android:attr/textColorPrimary"
+        app:layout_constraintBottom_toBottomOf="@id/video"
+        app:layout_constraintStart_toEndOf="@id/gallery"
+        app:layout_constraintTop_toTopOf="@id/video" />
 
     <ImageView
         android:id="@+id/attach"

--- a/presentation/src/main/res/values-ar/strings.xml
+++ b/presentation/src/main/res/values-ar/strings.xml
@@ -127,6 +127,8 @@
     <string name="compose_schedule_cd">جدوِل الرسالة</string>
     <string name="compose_contact_cd">إرفاق جهة اتصال</string>
     <string name="compose_contact_error">خطأ في قراءة جهة الاتصال</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">تحديد الشريحة</string>
     <string name="compose_sim_cd">%s محددة، غيّر شريحة SIM</string>

--- a/presentation/src/main/res/values-bn/strings.xml
+++ b/presentation/src/main/res/values-bn/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">বার্তা পাঠানোর সময়সূচি নির্ধারণ করো</string>
     <string name="compose_contact_cd">একটি পরিচিতি সংযুক্ত করুন</string>
     <string name="compose_contact_error">পরিচিতি পড়তে ত্রুটি</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">সিম %1$d (%2$s) নির্বাচিত</string>
     <string name="compose_sim_cd">নির্বাচিত, %s সিম কার্ড পরিবর্তন করুন</string>

--- a/presentation/src/main/res/values-cs/strings.xml
+++ b/presentation/src/main/res/values-cs/strings.xml
@@ -125,6 +125,8 @@
     <string name="compose_schedule_cd">Naplánovat zprávu</string>
     <string name="compose_contact_cd">Přiložit kontakt</string>
     <string name="compose_contact_error">Chyba čtení kontaktu</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">Vybrána SIM %1$d (%2$s)</string>
     <string name="compose_sim_cd">%s vybráno, změňte SIM kartu</string>

--- a/presentation/src/main/res/values-da/strings.xml
+++ b/presentation/src/main/res/values-da/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Planlæg besked</string>
     <string name="compose_contact_cd">Vedhæft en kontakt</string>
     <string name="compose_contact_error">Fejl ved læsning af kontakt</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) valgt</string>
     <string name="compose_sim_cd">%s valgt, skift SIM-kortet</string>

--- a/presentation/src/main/res/values-de/strings.xml
+++ b/presentation/src/main/res/values-de/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Plane Nachricht</string>
     <string name="compose_contact_cd">Kontakt anhängen</string>
     <string name="compose_contact_error">Fehler beim Lesen des Kontaktes</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) ausgewählt</string>
     <string name="compose_sim_cd">%s ausgewählt, SIM-Karte ändern</string>

--- a/presentation/src/main/res/values-el/strings.xml
+++ b/presentation/src/main/res/values-el/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Προγραμματισμός μηνύματος</string>
     <string name="compose_contact_cd">Επισύναψη επαφής</string>
     <string name="compose_contact_error">Πρόβλημα ανάγνωσης επαφής</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">Επελέγη το %s, αλλάξτε την κάρτα SIM</string>

--- a/presentation/src/main/res/values-el/strings.xml
+++ b/presentation/src/main/res/values-el/strings.xml
@@ -249,7 +249,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Συγχρονισμός μηνυμάτων</string>
     <string name="settings_sync_summary">Επανασυγχρονισμός μηνυμάτων με τη βάση δεδομένων SMS του Android</string>
     <string name="settings_about_title">Σχετικά με το QKSMS</string>

--- a/presentation/src/main/res/values-es/strings.xml
+++ b/presentation/src/main/res/values-es/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Programar mensaje</string>
     <string name="compose_contact_cd">Adjuntar un contacto</string>
     <string name="compose_contact_error">Error al leer contacto</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) seleccionada</string>
     <string name="compose_sim_cd">%s seleccionado, cambia la tarjeta SIM</string>

--- a/presentation/src/main/res/values-fa/strings.xml
+++ b/presentation/src/main/res/values-fa/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">زمان‌بندی پیام</string>
     <string name="compose_contact_cd">یک مخاطب پیوست کنید</string>
     <string name="compose_contact_error">خطا در خواندن مخاطب</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">سیم‌کارت %1$d (%2$s) انتخاب شد</string>
     <string name="compose_sim_cd">%s انتخاب شد، سیم‌کارت را عوض کنید</string>

--- a/presentation/src/main/res/values-fi/strings.xml
+++ b/presentation/src/main/res/values-fi/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Ajoita viesti</string>
     <string name="compose_contact_cd">Liitä yhteystieto</string>
     <string name="compose_contact_error">Yhteystiedon lukuvirhe</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) valittu</string>
     <string name="compose_sim_cd">%s valittu, vaihda SIM-korttia</string>

--- a/presentation/src/main/res/values-fr/strings.xml
+++ b/presentation/src/main/res/values-fr/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Programmer un message</string>
     <string name="compose_contact_cd">Joindre un contact</string>
     <string name="compose_contact_error">Erreur de lecture du contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) sélectionnée</string>
     <string name="compose_sim_cd">%s sélectionné, changer la carte SIM</string>

--- a/presentation/src/main/res/values-hi/strings.xml
+++ b/presentation/src/main/res/values-hi/strings.xml
@@ -249,7 +249,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QKSMS</string>

--- a/presentation/src/main/res/values-hi/strings.xml
+++ b/presentation/src/main/res/values-hi/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">संदेश अनुसूचित करें</string>
     <string name="compose_contact_cd">Attach a contact</string>
     <string name="compose_contact_error">Error reading contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s selected, change SIM card</string>

--- a/presentation/src/main/res/values-hr/strings.xml
+++ b/presentation/src/main/res/values-hr/strings.xml
@@ -252,7 +252,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Uskladi poruke</string>
     <string name="settings_sync_summary">Ponovno uskladite svoje poruke sa nativnom Android SMS bazom podataka</string>
     <string name="settings_about_title">O aplikaciji</string>

--- a/presentation/src/main/res/values-hr/strings.xml
+++ b/presentation/src/main/res/values-hr/strings.xml
@@ -124,6 +124,8 @@
     <string name="compose_schedule_cd">Schedule message</string>
     <string name="compose_contact_cd">Attach a contact</string>
     <string name="compose_contact_error">Error reading contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s selected, change SIM card</string>

--- a/presentation/src/main/res/values-hu/strings.xml
+++ b/presentation/src/main/res/values-hu/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Időzített küldés</string>
     <string name="compose_contact_cd">Személy hozzáadása</string>
     <string name="compose_contact_error">Hiba a személy olvasása közben</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s kiválasztva, cserélj SIM kártyát</string>

--- a/presentation/src/main/res/values-in/strings.xml
+++ b/presentation/src/main/res/values-in/strings.xml
@@ -122,6 +122,8 @@
     <string name="compose_schedule_cd">Jadwalkan pesan</string>
     <string name="compose_contact_cd">Lampirkan kontak</string>
     <string name="compose_contact_error">Galat membaca kontak</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) dipilih</string>
     <string name="compose_sim_cd">%s dipilih, ganti kartu SIM</string>

--- a/presentation/src/main/res/values-it/strings.xml
+++ b/presentation/src/main/res/values-it/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Pianifica messaggio</string>
     <string name="compose_contact_cd">Collegare un contatto</string>
     <string name="compose_contact_error">Errore nella lettura del contatto</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selezionata</string>
     <string name="compose_sim_cd">%s selezionato, cambiare SIM</string>

--- a/presentation/src/main/res/values-iw/strings.xml
+++ b/presentation/src/main/res/values-iw/strings.xml
@@ -125,6 +125,8 @@
     <string name="compose_schedule_cd">תזמון הודעה</string>
     <string name="compose_contact_cd">צרף איש קשר</string>
     <string name="compose_contact_error">שגיאה בקריאת איש קשר</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">נבחר SIM מס׳ %1$d ‏(%2$s)</string>
     <string name="compose_sim_cd">%s נבחר, החלף כרטיס SIM</string>

--- a/presentation/src/main/res/values-ja/strings.xml
+++ b/presentation/src/main/res/values-ja/strings.xml
@@ -122,6 +122,8 @@
     <string name="compose_schedule_cd">スケジュールメッセージ</string>
     <string name="compose_contact_cd">連絡先を添付する</string>
     <string name="compose_contact_error">連絡先の読み取りエラー</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) を選択しました</string>
     <string name="compose_sim_cd">%s 選択、SIMカードを交換</string>

--- a/presentation/src/main/res/values-ko/strings.xml
+++ b/presentation/src/main/res/values-ko/strings.xml
@@ -122,6 +122,8 @@
     <string name="compose_schedule_cd">예약 전송 메시지</string>
     <string name="compose_contact_cd">연락처 첨부</string>
     <string name="compose_contact_error">연락처를 불러오는 중에 문제가 발생했습니다</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) 선택 됨</string>
     <string name="compose_sim_cd">%s 선택됨, SIM 카드를 변경하세요.</string>

--- a/presentation/src/main/res/values-lt/strings.xml
+++ b/presentation/src/main/res/values-lt/strings.xml
@@ -255,7 +255,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sinchronizuoti pranešimus</string>
     <string name="settings_sync_summary">Iš naujo sinchronizuoti Android pranešimų duomenų bazę</string>
     <string name="settings_about_title">Apie QKSMS</string>

--- a/presentation/src/main/res/values-lt/strings.xml
+++ b/presentation/src/main/res/values-lt/strings.xml
@@ -125,6 +125,8 @@
     <string name="compose_schedule_cd">Schedule message</string>
     <string name="compose_contact_cd">Attach a contact</string>
     <string name="compose_contact_error">Error reading contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s selected, change SIM card</string>

--- a/presentation/src/main/res/values-nb/strings.xml
+++ b/presentation/src/main/res/values-nb/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Planlegg melding</string>
     <string name="compose_contact_cd">Legg til kontakt</string>
     <string name="compose_contact_error">Feil ved åpning av kontakt</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s er valgt, velg annet SIM-kort</string>

--- a/presentation/src/main/res/values-ne/strings.xml
+++ b/presentation/src/main/res/values-ne/strings.xml
@@ -249,7 +249,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QKSMS</string>

--- a/presentation/src/main/res/values-ne/strings.xml
+++ b/presentation/src/main/res/values-ne/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Schedule message</string>
     <string name="compose_contact_cd">Attach a contact</string>
     <string name="compose_contact_error">Error reading contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s selected, change SIM card</string>

--- a/presentation/src/main/res/values-nl/strings.xml
+++ b/presentation/src/main/res/values-nl/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Bericht plannen</string>
     <string name="compose_contact_cd">Een contactpersoon toevoegen</string>
     <string name="compose_contact_error">Fout bij het lezen van contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">Simkaart %1$d (%2$s) geselecteerd</string>
     <string name="compose_sim_cd">%s geselecteerd, wijzig SIM-kaart</string>

--- a/presentation/src/main/res/values-pl/strings.xml
+++ b/presentation/src/main/res/values-pl/strings.xml
@@ -125,6 +125,8 @@
     <string name="compose_schedule_cd">Zaplanuj wiadomość</string>
     <string name="compose_contact_cd">Załącz kontakt</string>
     <string name="compose_contact_error">Nie można odczytać kontaktu</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">Wybrano kartę SIM %1$d (%2$s)</string>
     <string name="compose_sim_cd">Wybrano %s, zmień kartę SIM</string>

--- a/presentation/src/main/res/values-pt-rBR/strings.xml
+++ b/presentation/src/main/res/values-pt-rBR/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Agendar mensagem</string>
     <string name="compose_contact_cd">Anexar contato</string>
     <string name="compose_contact_error">Erro ao ler contato</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s selecionado, altere o cartão SIM</string>

--- a/presentation/src/main/res/values-pt/strings.xml
+++ b/presentation/src/main/res/values-pt/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Agendar mensagem</string>
     <string name="compose_contact_cd">Anexar um contacto</string>
     <string name="compose_contact_error">Erro ao ler o contacto</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selecionado</string>
     <string name="compose_sim_cd">%s selecionado, alterar cartão SIM</string>

--- a/presentation/src/main/res/values-ro/strings.xml
+++ b/presentation/src/main/res/values-ro/strings.xml
@@ -124,6 +124,8 @@
     <string name="compose_schedule_cd">Schedule message</string>
     <string name="compose_contact_cd">Attach a contact</string>
     <string name="compose_contact_error">Error reading contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s selected, change SIM card</string>

--- a/presentation/src/main/res/values-ro/strings.xml
+++ b/presentation/src/main/res/values-ro/strings.xml
@@ -252,7 +252,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QKSMS</string>

--- a/presentation/src/main/res/values-ru/strings.xml
+++ b/presentation/src/main/res/values-ru/strings.xml
@@ -125,6 +125,8 @@
     <string name="compose_schedule_cd">Запланировать сообщение</string>
     <string name="compose_contact_cd">Прикрепить контакт</string>
     <string name="compose_contact_error">Ошибка чтения контакта</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">Выбрана SIM-карта %1$d (%2$s)</string>
     <string name="compose_sim_cd">Выбрано %s, сменить SIM-карту</string>

--- a/presentation/src/main/res/values-sk/strings.xml
+++ b/presentation/src/main/res/values-sk/strings.xml
@@ -125,6 +125,8 @@
     <string name="compose_schedule_cd">Naplánovať správu</string>
     <string name="compose_contact_cd">Pripojiť kontakt</string>
     <string name="compose_contact_error">Chyba čítania kontaktu</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">Vybrána SIM %1$d (%2$s)</string>
     <string name="compose_sim_cd">%s vybrané, zmeňte SIM kartu</string>

--- a/presentation/src/main/res/values-sl/strings.xml
+++ b/presentation/src/main/res/values-sl/strings.xml
@@ -125,6 +125,8 @@
     <string name="compose_schedule_cd">Načrtuj sporočilo</string>
     <string name="compose_contact_cd">Vstavi stik</string>
     <string name="compose_contact_error">Napaka pri branju stika</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s izbran, zamenjaj kartico SIM</string>

--- a/presentation/src/main/res/values-sr/strings.xml
+++ b/presentation/src/main/res/values-sr/strings.xml
@@ -124,6 +124,8 @@
     <string name="compose_schedule_cd">Планирај поруку</string>
     <string name="compose_contact_cd">Приложи контакт</string>
     <string name="compose_contact_error">Грешка при учитавању контакта</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">Изабрана SIM картица %1$d (%2$s)</string>
     <string name="compose_sim_cd">Изабрано: %s; промените SIM картицу</string>

--- a/presentation/src/main/res/values-sv/strings.xml
+++ b/presentation/src/main/res/values-sv/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Schemalägg meddelande</string>
     <string name="compose_contact_cd">Bifoga en kontakt</string>
     <string name="compose_contact_error">Fel uppstod när kontakt lästes in</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) valdes</string>
     <string name="compose_sim_cd">%s valt, byt SIM-kort</string>

--- a/presentation/src/main/res/values-th/strings.xml
+++ b/presentation/src/main/res/values-th/strings.xml
@@ -122,6 +122,8 @@
     <string name="compose_schedule_cd">กำหนดเวลาของข้อความ</string>
     <string name="compose_contact_cd">Attach a contact</string>
     <string name="compose_contact_error">Error reading contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s เลือก เปลี่ยน SIM การ์ด</string>

--- a/presentation/src/main/res/values-tl/strings.xml
+++ b/presentation/src/main/res/values-tl/strings.xml
@@ -249,7 +249,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QKSMS</string>

--- a/presentation/src/main/res/values-tl/strings.xml
+++ b/presentation/src/main/res/values-tl/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Schedule message</string>
     <string name="compose_contact_cd">Attach a contact</string>
     <string name="compose_contact_error">Error reading contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s selected, change SIM card</string>

--- a/presentation/src/main/res/values-tr/strings.xml
+++ b/presentation/src/main/res/values-tr/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Mesajı zamanlama</string>
     <string name="compose_contact_cd">Bir kişi ekle</string>
     <string name="compose_contact_error">Kişi okunurken hata oluştu</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) seçili</string>
     <string name="compose_sim_cd">Seçili, %s SIM kartı değiştirin</string>

--- a/presentation/src/main/res/values-uk/strings.xml
+++ b/presentation/src/main/res/values-uk/strings.xml
@@ -125,6 +125,8 @@
     <string name="compose_schedule_cd">Запланувати повідомлення</string>
     <string name="compose_contact_cd">Прикріпити контакт</string>
     <string name="compose_contact_error">Помилка читання контакту</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">Обрана SIM-карта %1$d (%2$s)</string>
     <string name="compose_sim_cd">%s обрано, змініть SIM-картку</string>

--- a/presentation/src/main/res/values-ur/strings.xml
+++ b/presentation/src/main/res/values-ur/strings.xml
@@ -249,7 +249,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QKSMS</string>

--- a/presentation/src/main/res/values-ur/strings.xml
+++ b/presentation/src/main/res/values-ur/strings.xml
@@ -123,6 +123,8 @@
     <string name="compose_schedule_cd">Schedule message</string>
     <string name="compose_contact_cd">Attach a contact</string>
     <string name="compose_contact_error">Error reading contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s selected, change SIM card</string>

--- a/presentation/src/main/res/values-vi/strings.xml
+++ b/presentation/src/main/res/values-vi/strings.xml
@@ -122,6 +122,8 @@
     <string name="compose_schedule_cd">Hẹn giờ tin nhắn</string>
     <string name="compose_contact_cd">Đính kèm liên hệ</string>
     <string name="compose_contact_error">Lỗi đọc liên hệ</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">Đã chọn SIM %1$d (%2$s)</string>
     <string name="compose_sim_cd">%s đã được chọn, hãy đổi thẻ SIM</string>

--- a/presentation/src/main/res/values-zh-rCN/strings.xml
+++ b/presentation/src/main/res/values-zh-rCN/strings.xml
@@ -122,6 +122,8 @@
     <string name="compose_schedule_cd">定时消息</string>
     <string name="compose_contact_cd">附加联系人</string>
     <string name="compose_contact_error">读取联系人时出错</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">已选择 SIM 卡 %1$d (%2$s)</string>
     <string name="compose_sim_cd">%s 已选择，更改 SIM 卡</string>

--- a/presentation/src/main/res/values-zh/strings.xml
+++ b/presentation/src/main/res/values-zh/strings.xml
@@ -122,6 +122,8 @@
     <string name="compose_schedule_cd">排程訊息</string>
     <string name="compose_contact_cd">附加聯絡人</string>
     <string name="compose_contact_error">讀取聯絡人時出錯</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">已選取%1$d (%2$s) SIM卡</string>
     <string name="compose_sim_cd">%s 已選擇，變更 SIM 卡</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -137,6 +137,8 @@
     <string name="compose_schedule_cd">Schedule message</string>
     <string name="compose_contact_cd">Attach a contact</string>
     <string name="compose_contact_error">Error reading contact</string>
+    <string name="compose_audio_cd">Attach audio</string>
+    <string name="compose_video_cd">Attach a video</string>
     <!-- Example: SIM 1 (Verizon) selected-->
     <string name="compose_sim_changed_toast">SIM %1$d (%2$s) selected</string>
     <string name="compose_sim_cd">%s selected, change SIM card</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -273,7 +273,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QKSMS</string>


### PR DESCRIPTION
Allows video and audio attachments to be sent from the app. Previously they could only be received and viewed. Please give me feedback on my changes. I am willing to change how some of it is done.

Fixes #1921 and fixes #1654